### PR TITLE
Revamp nitro boost alerts and logs

### DIFF
--- a/cogs/commands/general.py
+++ b/cogs/commands/general.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Union
 
@@ -47,6 +48,36 @@ class General(Cog):
                 await ctx.message.delete()
             except discord.errors.HTTPException:
                 pass
+        
+    @commands.bot_has_permissions(read_message_history=True, add_reactions=True)
+    @commands.before_invoke(record_usage)
+    @commands.command(name='testing')
+    async def testing(self, ctx, id):
+        ticket = discord.utils.get(discord.utils.get(ctx.guild.categories, 
+                                id=config.ticket_category_id).text_channels, 
+                                name=f"ticket-123949837791002625")
+        messages = await ticket.history().flatten()
+
+        for message in messages[::-1]:
+            await ctx.reply(message)
+            await asyncio.sleep(2)
+
+    @commands.bot_has_permissions(read_message_history=True, add_reactions=True)
+    @commands.before_invoke(record_usage)
+    @commands.command(name='testing2')
+    async def testing2(self, ctx):
+        general = discord.utils.get(ctx.guild.channels, id=631919775613845504)
+        boost_id = 831964491662622730
+        test = await general.fetch_message(boost_id)
+        
+        if test.type.value == 8:
+            await ctx.reply(test.author.mention)
+
+
+
+
+
+
 
 
 def setup(bot: Bot) -> None:

--- a/handlers/boosts.py
+++ b/handlers/boosts.py
@@ -19,7 +19,7 @@ async def on_new_boost(before, after):
         embed.set_image(url="https://i.imgur.com/O8R98p9.gif")
         await before.system_channel.send(embed=embed)
 
-        # Sent a log in #nitro-logs letting the staff know someone boosted with a link to a message near the boost.
+        # Send a log in #nitro-logs letting the staff know someone boosted with a link to a message near their boost.
         nitro_logs = discord.utils.get(after.guild.channels, id=config.nitro_logs)
         embed = embeds.make_embed(author=False, color="nitro_pink")
         last_message = await after.guild.system_channel.fetch_message(after.guild.system_channel.last_message_id)
@@ -47,11 +47,12 @@ async def on_removed_boost(before, after):
 # Proces when a user who previously hasn't boosted the server boosts.
 async def process_new_booster(before, after):
     if before.premium_since is None and after.premium_since is not None:
-        channel = discord.utils.get(after.guild.channels, id=config.nitro_logs)
         embed = embeds.make_embed(author=False, color="nitro_pink")
-        embed.title = "New booster"
-        embed.description = f"""{after.mention} boosted the server. We're now at {after.guild.premium_subscription_count} boosts."""
-        await channel.send(embed=embed)
+        embed.title = f"{after} boosted the server!"
+        embed.description = f"""{after.mention}, thank you so much for the server boost! We are now at {after.premium_subscription_count} boosts!
+        You can contact any <@&763031634379276308> member with a [hex color](https://www.google.com/search?q=hex+color) and your desired role name for a custom booster role."""
+        embed.set_image(url="https://i.imgur.com/O8R98p9.gif")
+        await before.system_channel.send(embed=embed)
 
         log.info(f'{after.mention} boosted {after.guild.name}.')
 


### PR DESCRIPTION
Right now, the bot sends a generic embed in the system messages channel (#general) when we receive a boost thanking the user for boosting. This doesn't include the users name because the user's premium_state only updates when boosting for the first time or removing all of their boosts entirely. 

With the revamp, we will handle both boosting for the first time as well as adding additional boosts to the server under the same embed that includes a mention of the user. The way to accomplish this would be to handle fresh boosts as we already do while adding the users name/mention to the embed:

`"A new booster appeared"` -> `"User#0001 boosted the server"`
`"Thank you so much for the server boost! ..."` -> `"<@User#0001>, thank you so much for the server boost!"`

To handle boosts from users already boosting which only receive an event via `if after.premium_subscription_count <> before.premium_subscription_count:` we will have to iterate over the recent message history of the system commands channel when the guild's `premium_subscription_count` changes to figure out the user who boosted the guild. 

This should be easy to accomplish by iterating over the history for recent messages that are `type.value == 8:` as shown in the `general.py` `!testing2` command here: https://github.com/ranimepiracy/Chiya/blob/8226b78d9914d3d3f34eb72cdcbcb517ef720cc5/cogs/commands/general.py#L68

From there, we can use the message author of that message (even though it's a system message, the author value is attributed to the booster) as the user's mention and send an embed identical to the one called from the other function.

TODO:

- [ ] Make new users boosting and users boosting again have the same embed
- [ ] Make both case-scenario embeds mention the user as stated above.
- [ ] Make both case-scenarios have the same style embed in #nitro-logs
- [ ] Make sure that the following cases are accounted for in #nitro-logs:
    - [ ] New users boosting is logged
    - [ ] Previous boosting users boosting again is logged
    - [ ] Users ending their boosting is logged
    - [ ] A user who is boosting the server removed one of their boosts (no way to properly figure out who)
- [ ] Add an embed link to the boost event/message in #general to the #nitro-logs embed 
