### PR TITLE
Implemented editing mod action reasons, moved notes to mod_logs

### DIFF
--- a/utils/database.py
+++ b/utils/database.py
@@ -22,13 +22,6 @@ def setup_db():
     mod_logs.create_column("timestamp", db.types.bigint)
     mod_logs.create_column("reason", db.types.text)
     mod_logs.create_column("type", db.types.text)
-    
-    # Create mod_logs table and columns to store moderator actions.
-    mod_notes = db.create_table("mod_notes")
-    mod_notes.create_column("user_id", db.types.bigint)
-    mod_notes.create_column("mod_id", db.types.bigint)
-    mod_notes.create_column("timestamp", db.types.bigint)
-    mod_notes.create_column("note", db.types.text)
 
     # Create remind_me table and columns to store remind_me messages.
     remind_me = db.create_table("remind_me")


### PR DESCRIPTION
- Implemented editing mod action reasons.
- Migrated mod_notes to mod_logs due to nearly identical schema.
- Added notes to the search command.
- Removed the mod_notes table builder.
- Added the log ID to the search result title.
- Replaced some single quotes with double quotes.