### PR TITLE
Manually removed mutes are now auto reapplied, changed is_muted logic

### DIFF
--- a/cogs/commands/moderation/mutes.py
+++ b/cogs/commands/moderation/mutes.py
@@ -64,8 +64,11 @@ class MuteCog(Cog):
                 user_id=member.id, mod_id=moderator.id, timestamp=int(time.time()), reason=reason, type="unmute"
             ))
 
-    async def is_user_muted(self, ctx: SlashContext, member: discord.Member) -> bool:
-        if discord.utils.get(ctx.guild.roles, id=config.role_muted) in member.roles:
+    async def is_user_muted(self, member: discord.Member, ctx: SlashContext = None, guild: discord.Guild = None) -> bool:
+        guild = guild or ctx.guild
+        category = discord.utils.get(guild.categories, id=config.ticket_category_id)
+        mute_channel = discord.utils.get(guild.text_channels, name=f"mute-{member.id}")
+        if mute_channel in category.text_channels:
             return True
         return False
 
@@ -142,7 +145,6 @@ class MuteCog(Cog):
         return channel
 
     async def archive_mute_channel(self, user_id: int, reason: str = None, ctx: SlashContext = None, guild: int = None):
-
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         if not reason:
             reason = "No reason provided."

--- a/cogs/listeners/mutes.py
+++ b/cogs/listeners/mutes.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import dataset
+import discord
 from discord import Member
 from discord.ext import commands
 
@@ -20,6 +21,17 @@ class MutesHandler(commands.Cog):
 
     @commands.Cog.listener()
     async def on_member_remove(self, member: Member) -> None:
+        """Event Listener which is called when a Member leaves a Guild.
+
+        Args:
+            member (Member): The member who left.
+
+        Note:
+            This requires Intents.members to be enabled.
+
+        For more information:
+            https://discordpy.readthedocs.io/en/latest/api.html#discord.on_member_remove
+        """
         with dataset.connect(database.get_db()) as db:
             action = db['timed_mod_actions'].find_one(user_id=member.id, is_done=False, action_type='mute')
             guild = member.guild
@@ -57,7 +69,30 @@ class MutesHandler(commands.Cog):
                     unmute_reason="Mute channel archived after member banned due to mute evasion."
                 )
                 await channel.send(embed=embed)
+    
+    @commands.Cog.listener()
+    async def on_member_update(self, before: Member, after: Member) -> None:
+        """Event Listener which is called when a Member updates their profile.
 
+        Args:
+            before (Member): The updated member’s old info.
+            after (Member): The updated member’s updated info.
+
+        Note:
+            This requires Intents.members to be enabled.
+
+        For more information:
+            https://discordpy.readthedocs.io/en/latest/api.html#discord.on_member_update
+        """
+
+        # If the mute role is manually removed from a user, re-add it automatically.
+        # Only do this operation on role count changes to try avoiding hitting Discord API unnecessarily.
+        if len(before.roles) != len(after.roles):
+            mute_role = discord.utils.get(before.guild.roles, id=config.role_muted)
+            if mute_role in before.roles and mute_role not in after.roles:
+                mute_cog = self.bot.get_cog("MuteCog")
+                if await mute_cog.is_user_muted(guild=before.guild, member=before):
+                    await before.add_roles(mute_role)
 
 def setup(bot) -> None:
     """Load the cog."""


### PR DESCRIPTION
- If a user has the "Muted" role removed from them when they are still muted, Chiya will automatically reapply it.

- Changed the logic for is_user_muted because moderators can easily remove the "Muted" role which would break the command but only admins can delete mute channels (or Chiya).