### PR TITLE
Moved log_level to environment variables

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,9 +8,8 @@ import coloredlogs
 
 import config
 
-log_level = config.log_level
-
-if log_level is None:
+log_level = os.getenv("LOG_LEVEL")
+if not log_level:
     log_level = "NOTSET"
 
 # Adding Trace to enchance debugging verbose logs. DO NOT USE FOR PRODUCTION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         - MYSQL_DATABASE=chiya
         - MYSQL_USER=chiya
         - MYSQL_PASSWORD=${MYSQL_PASSWORD}
-        - LOG_LEVEL=info
+        - LOG_LEVEL=${LOG_LEVEL}
   db:
     image: mariadb
     restart: unless-stopped


### PR DESCRIPTION
* Moved log_level to environment variables and added the relevant `docker-compose.yml` bit. This was already supposed to be in the environment variables and is in the Docker variables in the old README but was actually reading from the config?