### PR TITLE
Add PrivateBin output support for code evaluation 

### DIFF
--- a/cogs/commands/moderation/administration.py
+++ b/cogs/commands/moderation/administration.py
@@ -136,6 +136,8 @@ class AdministrationCog(Cog):
                 # Maybe the case where there's no output?
                 self._last_result = ret
                 output = f'```py\n{value}{ret}\n```'
+                if len(output) > 512:
+                        output = self.upload_to_privatebin(value)
                 embed.add_field(name="Output:", value=output, inline=False)
                 await ctx.send(embed=embed)
 

--- a/cogs/commands/moderation/administration.py
+++ b/cogs/commands/moderation/administration.py
@@ -7,11 +7,10 @@ import traceback
 from contextlib import redirect_stdout
 
 import discord
-from discord.ext import commands
-from discord.ext.commands import Cog, Bot, Context
 import privatebinapi
-
 from cogs.commands import settings
+from discord.ext import commands
+from discord.ext.commands import Bot, Cog, Context
 from utils import embeds
 from utils.record import record_usage
 
@@ -20,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class AdministrationCog(Cog):
-    """ Administration Cog Cog """
+    """Administration Cog Cog"""
 
     def __init__(self, bot):
         self.bot = bot
@@ -29,16 +28,18 @@ class AdministrationCog(Cog):
     def _cleanup_code(self, content):
         """Automatically removes code blocks from the code."""
         # remove ```py\n```
-        if content.startswith('```') and content.endswith('```'):
-            return '\n'.join(content.split('\n')[1:-1])
+        if content.startswith("```") and content.endswith("```"):
+            return "\n".join(content.split("\n")[1:-1])
 
         # remove `foo`
-        return content.strip('` \n')
-    
+        return content.strip("` \n")
+
     def upload_to_privatebin(self, text_to_be_uploaded: str) -> str:
-        uploaded_info = privatebinapi.send("https://bin.piracy.moe", text=text_to_be_uploaded, expiration='never')
+        uploaded_info = privatebinapi.send(
+            "https://bin.piracy.moe", text=text_to_be_uploaded, expiration="never"
+        )
         if uploaded_info:
-            return uploaded_info['full_url']
+            return uploaded_info["full_url"]
         # returning a zero width whitespace character
         return "​"
 
@@ -67,23 +68,22 @@ class AdministrationCog(Cog):
         """Evaluates input as Python code."""
         # Required environment variables.
         env = {
-            'bot': self.bot,
-            'ctx': ctx,
-            'channel': ctx.channel,
-            'author': ctx.author,
-            'guild': ctx.guild,
-            'message': ctx.message,
-            'embeds': embeds,
-            '_': self._last_result
+            "bot": self.bot,
+            "ctx": ctx,
+            "channel": ctx.channel,
+            "author": ctx.author,
+            "guild": ctx.guild,
+            "message": ctx.message,
+            "embeds": embeds,
+            "_": self._last_result,
         }
         # Creating embed.
-        embed = discord.Embed(title="Evaluating.", color=0xb134eb)
+        embed = discord.Embed(title="Evaluating.", color=0xB134EB)
         env.update(globals())
 
         # Calling cleanup command to remove the markdown traces.
         body = self._cleanup_code(body)
-        embed.add_field(
-            name="Input:", value=f"```py\n{body}\n```", inline=False)
+        embed.add_field(name="Input:", value=f"```py\n{body}\n```", inline=False)
         # Output stream.
         stdout = io.StringIO()
 
@@ -95,7 +95,7 @@ class AdministrationCog(Cog):
             exec(to_compile, env)
         except Exception as e:
             # In case there's an error, add it to the embed, send and stop.
-            errors = f'```py\n{e.__class__.__name__}: {e}\n```'
+            errors = f"```py\n{e.__class__.__name__}: {e}\n```"
             if len(errors) > 512:
                 errors = self.upload_to_privatebin(f"{e.__class__.__name__}: {e}")
 
@@ -103,14 +103,14 @@ class AdministrationCog(Cog):
             await ctx.send(embed=embed)
             return errors
 
-        func = env['func']
+        func = env["func"]
         try:
             with redirect_stdout(stdout):
                 ret = await func()
         except Exception:
             # In case there's an error, add it to the embed, send and stop.
             value = stdout.getvalue()
-            errors = f'```py\n{value}{traceback.format_exc()}\n```'
+            errors = f"```py\n{value}{traceback.format_exc()}\n```"
             if len(errors) > 512:
                 errors = self.upload_to_privatebin(f"{value}{traceback.format_exc()}")
 
@@ -120,32 +120,31 @@ class AdministrationCog(Cog):
         else:
             value = stdout.getvalue()
             try:
-                await ctx.message.add_reaction('\u2705')
+                await ctx.message.add_reaction("\u2705")
             except:
                 pass
 
             if ret is None:
                 if value:
                     # Output.
-                    output = f'```py\n{value}\n```'
+                    output = f"```py\n{value}\n```"
                     if len(output) > 512:
                         output = self.upload_to_privatebin(value)
-                    embed.add_field(
-                        name="Output:", value=output, inline=False)
+                    embed.add_field(name="Output:", value=output, inline=False)
                     await ctx.send(embed=embed)
             else:
                 # Maybe the case where there's no output?
                 self._last_result = ret
-                output = f'```py\n{value}{ret}\n```'
+                output = f"```py\n{value}{ret}\n```"
                 if len(output) > 512:
-                        output = self.upload_to_privatebin(value)
+                    output = self.upload_to_privatebin(value)
                 embed.add_field(name="Output:", value=output, inline=False)
                 await ctx.send(embed=embed)
 
     @commands.is_owner()
     @utilities.command(name="reload")
     async def reload_cog(self, ctx: commands.Context, name_of_cog: str = None):
-        """ Reloads specified cog or all cogs. """
+        """Reloads specified cog or all cogs."""
 
         regex = r"(?<=<).*(?=\..* object at 0x.*>)"
         if name_of_cog is not None and name_of_cog in ctx.bot.cogs:
@@ -156,7 +155,7 @@ class AdministrationCog(Cog):
 
             except commands.ExtensionError as e:
                 await ctx.message.add_reaction("❌")
-                await ctx.send(f'{e.__class__.__name__}: {e}')
+                await ctx.send(f"{e.__class__.__name__}: {e}")
 
             else:
                 await ctx.message.add_reaction("✔")
@@ -174,7 +173,7 @@ class AdministrationCog(Cog):
                         self.bot.reload_extension(cog.replace("/", ".")[:-3])
             except commands.ExtensionError as e:
                 await ctx.message.add_reaction("❌")
-                await ctx.send(f'{e.__class__.__name__}: {e}')
+                await ctx.send(f"{e.__class__.__name__}: {e}")
 
             else:
                 await ctx.message.add_reaction("✔")
@@ -188,7 +187,7 @@ class AdministrationCog(Cog):
     @commands.before_invoke(record_usage)
     @commands.command(name="rules")
     async def rules(self, ctx: Context):
-        """ Generates the #rules channel embeds. """
+        """Generates the #rules channel embeds."""
 
         # Captain Karen header image embed
         embed = embeds.make_embed(color="quotes_grey")
@@ -196,27 +195,91 @@ class AdministrationCog(Cog):
         await ctx.send(embed=embed)
 
         # The actual rules embed
-        embed = embeds.make_embed(title="📃  Discord Server Rules", color="quotes_grey", description="This list is not all-encompassing and you may be actioned for a reason outside of these rules. Use common sense when interacting in our community.")
-        embed.add_field(name="Rule 1: Do not send copyright-infringing material.", inline=False, value="> Linking to torrents, pirated stream links, direct download links, or uploading files over Discord puts our community at risk of being shut down. We are a discussion community, not a file-sharing hub.")
-        embed.add_field(name="Rule 2: Be courteous and mindful of others.", inline=False, value="> Do not engage in toxic behavior such as spamming, derailing conversations, attacking other users, or attempting to instigate drama. Bigotry will not be tolerated. Avoid problematic avatars, usernames, or nicknames.")
-        embed.add_field(name="Rule 3: Do not post self-promotional content.", inline=False, value="> We are not a billboard nor the place to advertise your Discord server, app, website, service, etc.")
-        embed.add_field(name="Rule 4: Do not post unmarked spoilers.", inline=False, value="> Use spoiler tags and include what series or episode your spoiler is in reference to outside the spoiler tag so people don't blindly click a spoiler.")
-        embed.add_field(name="Rule 5: Do not backseat moderate.", inline=False, value="> If you see someone breaking the rules or have something to report, please submit a <#829861810999132160> ticket.")
-        embed.add_field(name="Rule 6: Do not abuse pings.", inline=False, value="> Do not ping staff outside of conversation unless necessary. Do not ping VIP users for questions or help with their service. Do not spam or ghost ping other users.")
-        embed.add_field(name="Rule 7: Do not beg, buy, sell, or trade.", inline=False, value="> This includes, but is not limited to, server ranks, roles, permissions, giveaways, private community invites, or any digital or physical goods.")
-        embed.add_field(name="Rule 8: Follow the Discord Community Guidelines and Terms of Service.", inline=False, value="> The Discord Community Guidelines and Terms of Service govern all servers on the platform. Please familarize yourself with them and the restrictions that come with them. \n> \n> https://discord.com/guidelines \n> https://discord.com/terms")
+        embed = embeds.make_embed(
+            title="📃  Discord Server Rules",
+            color="quotes_grey",
+            description="This list is not all-encompassing and you may be actioned for a reason outside of these rules. Use common sense when interacting in our community.",
+        )
+        embed.add_field(
+            name="Rule 1: Do not send copyright-infringing material.",
+            inline=False,
+            value="> Linking to torrents, pirated stream links, direct download links, or uploading files over Discord puts our community at risk of being shut down. We are a discussion community, not a file-sharing hub.",
+        )
+        embed.add_field(
+            name="Rule 2: Be courteous and mindful of others.",
+            inline=False,
+            value="> Do not engage in toxic behavior such as spamming, derailing conversations, attacking other users, or attempting to instigate drama. Bigotry will not be tolerated. Avoid problematic avatars, usernames, or nicknames.",
+        )
+        embed.add_field(
+            name="Rule 3: Do not post self-promotional content.",
+            inline=False,
+            value="> We are not a billboard nor the place to advertise your Discord server, app, website, service, etc.",
+        )
+        embed.add_field(
+            name="Rule 4: Do not post unmarked spoilers.",
+            inline=False,
+            value="> Use spoiler tags and include what series or episode your spoiler is in reference to outside the spoiler tag so people don't blindly click a spoiler.",
+        )
+        embed.add_field(
+            name="Rule 5: Do not backseat moderate.",
+            inline=False,
+            value="> If you see someone breaking the rules or have something to report, please submit a <#829861810999132160> ticket.",
+        )
+        embed.add_field(
+            name="Rule 6: Do not abuse pings.",
+            inline=False,
+            value="> Do not ping staff outside of conversation unless necessary. Do not ping VIP users for questions or help with their service. Do not spam or ghost ping other users.",
+        )
+        embed.add_field(
+            name="Rule 7: Do not beg, buy, sell, or trade.",
+            inline=False,
+            value="> This includes, but is not limited to, server ranks, roles, permissions, giveaways, private community invites, or any digital or physical goods.",
+        )
+        embed.add_field(
+            name="Rule 8: Follow the Discord Community Guidelines and Terms of Service.",
+            inline=False,
+            value="> The Discord Community Guidelines and Terms of Service govern all servers on the platform. Please familarize yourself with them and the restrictions that come with them. \n> \n> https://discord.com/guidelines \n> https://discord.com/terms",
+        )
         await ctx.send(embed=embed)
 
         # /r/animepiracy links embed
         embed = embeds.make_embed(title="🔗  Our Links", color="quotes_grey")
-        embed.add_field(name="Reddit:", inline=True, value="> [/r/animepiracy](https://reddit.com/r/animepiracy)")
-        embed.add_field(name="Discord:", inline=True, value="> [discord.gg/piracy](https://discord.gg/piracy)")
-        embed.add_field(name="Index:", inline=True, value="> [piracy.moe](https://piracy.moe)")
-        embed.add_field(name="Wiki:", inline=True, value="> [wiki.piracy.moe](https://wiki.piracy.moe)")
-        embed.add_field(name="Seadex:", inline=True, value="> [releases.moe](https://releases.moe)")
-        embed.add_field(name="GitHub:", inline=True, value="> [github.com/ranimepiracy](https://github.com/ranimepiracy)")
-        embed.add_field(name="Twitter:", inline=True, value="> [@ranimepiracy](https://twitter.com/ranimepiracy)")
-        embed.add_field(name="Uptime Status:", inline=True, value="> [status.piracy.moe](https://status.piracy.moe/)")
+        embed.add_field(
+            name="Reddit:",
+            inline=True,
+            value="> [/r/animepiracy](https://reddit.com/r/animepiracy)",
+        )
+        embed.add_field(
+            name="Discord:",
+            inline=True,
+            value="> [discord.gg/piracy](https://discord.gg/piracy)",
+        )
+        embed.add_field(
+            name="Index:", inline=True, value="> [piracy.moe](https://piracy.moe)"
+        )
+        embed.add_field(
+            name="Wiki:",
+            inline=True,
+            value="> [wiki.piracy.moe](https://wiki.piracy.moe)",
+        )
+        embed.add_field(
+            name="Seadex:", inline=True, value="> [releases.moe](https://releases.moe)"
+        )
+        embed.add_field(
+            name="GitHub:",
+            inline=True,
+            value="> [github.com/ranimepiracy](https://github.com/ranimepiracy)",
+        )
+        embed.add_field(
+            name="Twitter:",
+            inline=True,
+            value="> [@ranimepiracy](https://twitter.com/ranimepiracy)",
+        )
+        embed.add_field(
+            name="Uptime Status:",
+            inline=True,
+            value="> [status.piracy.moe](https://status.piracy.moe/)",
+        )
         await ctx.send(embed=embed)
 
         # Clean up the command invoker
@@ -227,10 +290,15 @@ class AdministrationCog(Cog):
     @commands.before_invoke(record_usage)
     @commands.command(name="createticketembed")
     async def create_ticket_embed(self, ctx: Context):
-        embed = embeds.make_embed(title="🎫 Create a new modmail ticket",
-                                  description="Click the react below to create a new modmail ticket.",
-                                  color="default")
-        embed.add_field(name="Warning:", value="Serious inquiries only. Abuse may result in warning or ban.")
+        embed = embeds.make_embed(
+            title="🎫 Create a new modmail ticket",
+            description="Click the react below to create a new modmail ticket.",
+            color="default",
+        )
+        embed.add_field(
+            name="Warning:",
+            value="Serious inquiries only. Abuse may result in warning or ban.",
+        )
         spawned = await ctx.send(embed=embed)
         await spawned.add_reaction("🎫")
         await ctx.message.delete()
@@ -238,9 +306,11 @@ class AdministrationCog(Cog):
     @commands.is_owner()
     @commands.bot_has_permissions(embed_links=True, send_messages=True)
     @commands.before_invoke(record_usage)
-    @commands.command(name="createcolorrolesembed", aliases=['ccre'])
+    @commands.command(name="createcolorrolesembed", aliases=["ccre"])
     async def create_color_roles_embed(self, ctx: Context):
-        embed = discord.Embed(description=f"You can react to one of the squares below to be assigned a colored user role. If you are interested in a different color, you can become a <@&{settings.get_value('role_server_booster')}> to receive a custom colored role.")
+        embed = discord.Embed(
+            description=f"You can react to one of the squares below to be assigned a colored user role. If you are interested in a different color, you can become a <@&{settings.get_value('role_server_booster')}> to receive a custom colored role."
+        )
         msg = await ctx.send(embed=embed)
 
         # API call to fetch all the emojis to cache, so that they work in future calls
@@ -259,7 +329,7 @@ class AdministrationCog(Cog):
     @commands.is_owner()
     @commands.bot_has_permissions(embed_links=True, send_messages=True)
     @commands.before_invoke(record_usage)
-    @commands.command(name="createassignablerolesembed", aliases=['care'])
+    @commands.command(name="createassignablerolesembed", aliases=["care"])
     async def create_assignable_roles_embed(self, ctx: Context):
         role_assignment_text = """
         You can react to one of the emotes below to assign yourself an event role.
@@ -288,6 +358,6 @@ class AdministrationCog(Cog):
 
 
 def setup(bot: Bot) -> None:
-    """ Load the AdministrationCog cog. """
+    """Load the AdministrationCog cog."""
     bot.add_cog(AdministrationCog(bot))
     log.info("Commands loaded: administration")

--- a/cogs/commands/moderation/administration.py
+++ b/cogs/commands/moderation/administration.py
@@ -35,11 +35,12 @@ class AdministrationCog(Cog):
         # remove `foo`
         return content.strip('` \n')
     
-    def upload_to_privatebin(self, payload: str) -> str:
-        try:
-            return privatebinapi.send("https://bin.piracy.moe", text=payload, expiration='never', burn_after_reading=True)["full_url"]
-        except:
-            return "Error uploading to privatebin. Is privatebin up?"
+    def upload_to_privatebin(self, text_to_be_uploaded: str) -> str:
+        uploaded_info = privatebinapi.send("https://bin.piracy.moe", text=text_to_be_uploaded, expiration='never')
+        if uploaded_info:
+            return uploaded_info['full_url']
+        # returning a zero width whitespace character
+        return "​"
 
     @commands.before_invoke(record_usage)
     @commands.group(aliases=["u", "ul"])


### PR DESCRIPTION
Longer command outputs and errors, exceeding 512 characters will be uploaded to privatebin, to prevent the "Form Length Exceeded" errors when making the embed.