### PR TITLE
Implemented /trackerstatus command

### DIFF
--- a/chiya/cogs/commands/trackerstatus.py
+++ b/chiya/cogs/commands/trackerstatus.py
@@ -1,0 +1,89 @@
+import logging
+
+import requests
+from discord.commands import slash_command, context, Option
+from discord.ext import commands, tasks
+
+from chiya import config
+from chiya.utils import embeds
+
+
+log = logging.getLogger(__name__)
+trackers = ["AR", "BTN", "GGn", "PTP", "RED", "OPS"]
+
+
+class TrackerStatusCommands(commands.Cog):
+    # TODO: Add support for trackers that offer their own status page.
+    # https://status.animebytes.tv/
+    # http://about.empornium.ph/
+    # https://status.myanonamouse.net/
+    # http://is.morethantv.online/
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.cache = {}
+        self.refresh_data.start()
+
+    def cog_unload(self) -> None:
+        self.refresh_data.cancel()
+
+    @tasks.loop(seconds=60)
+    async def refresh_data(self):
+        """
+        Grabs the latest API data from trackerstatus.info and caches it locally
+        every 60 seconds, respecting API limits.
+        """
+        for tracker in trackers:
+            try:
+                r = requests.get(url=f"https://{tracker}.trackerstatus.info/api/status/")
+                r.raise_for_status()
+            except (requests.exceptions.RequestException, requests.exceptions.HTTPError) as e:
+                log.error(e)
+                pass
+
+            if r.status_code == 200:
+                self.cache[tracker] = r.json()
+
+    def normalize_value(self, value):
+        """
+        Converts API data values into user-friendly text with status availability icon.
+        """
+        match value:
+            case "1":
+                return "<:status_online:596576749790429200> Online"
+            case "2":
+                return "<:status_dnd:596576774364856321> Unstable"
+            case "0":
+                return "<:status_offline:596576752013279242> Offline"
+
+    @slash_command(guild_ids=config["guild_ids"], description="Get tracker uptime statuses", default_permission=True)
+    async def trackerstatus(
+        self,
+        ctx: context.ApplicationContext,
+        tracker: Option(
+            str,
+            description="Tracker to get uptime statuses for",
+            choices=trackers,
+            required=True
+        )
+    ) -> None:
+        # TODO: Change the color of the embed to green if all services are online,
+        # yellow if one of the services is offline, and grey or red if all are offline.
+        await ctx.defer()
+
+        embed = embeds.make_embed(
+            ctx=ctx,
+            title=f"Tracker Status: {tracker}",
+        )
+
+        for key, value in self.cache[tracker].items():
+            # Skip over any keys that we don't want to return in the embed.
+            if key in ["tweet", "TrackerHTTPAddresses", "TrackerHTTPSAddresses"]:
+                continue
+            embed.add_field(name=key, value=self.normalize_value(value), inline=True)
+
+        await ctx.send_followup(embed=embed)
+
+
+def setup(bot: commands.Bot) -> None:
+    bot.add_cog(TrackerStatusCommands(bot))
+    log.info("Commands loaded: trackerstatus")


### PR DESCRIPTION
Relies on trackerstatus.info for API data at the moment. 

There are plans noted in the comments under the "TODO:" for supporting trackers that offer their own status pages rather than solely relying on trackerstatus.info. There are also plans in the comments for changing the embed color based on the availability of the tracker's services.

It would be nice to also support some more features not documented in the comments like displaying the full tracker name in the title instead of just the acronym, using the embed thumbnail to display the tracker favicon, and eventually supporting tracking our own data. 

There are a few small places that could use improvement in the code:
- The `log.error(e)` could use some context in the outputted string before the `e` so it's more apparent where the console log is coming from. 
- We might also want to consider raising the `refresh_data()` loop time to something like 5 minutes in the future because although we're respecting the API limits it seems a bit excessive to query this API 1440 times a day.