### PR TITLE
Moved cog loading into on_ready and made the loading more dynamic

### DIFF
--- a/chiya/bot.py
+++ b/chiya/bot.py
@@ -37,13 +37,10 @@ async def on_ready() -> None:
     await bot.change_presence(
         activity=discord.Activity(type=discord.ActivityType.listening, name=config["bot"]["status"])
     )
-
-    # TODO: Move this to an admin command rather than running every time the bot loads.
-    # await bot.register_commands()
+    for cog in glob.iglob(os.path.join("cogs", "**", "[!^_]*.py"), root_dir=os.path.dirname(__file__), recursive=True):
+        bot.load_extension(cog.replace("/", ".").replace("\\", ".").replace(".py", ""))
 
 
 if __name__ == "__main__":
-    for cog in glob.iglob(os.path.join("cogs", "**", "[!^_]*.py"), root_dir="chiya", recursive=True):
-        bot.load_extension(cog.replace("/", ".").replace("\\", ".").replace(".py", ""))
     database.Database().setup()
     bot.run(config["bot"]["token"])


### PR DESCRIPTION
The previous implementation made it so that cogs could not access any bot values during their initialization because the bot was loading the cogs before connecting to the Discord network. This fixes that going forward.

The root_dir for the cog loading was changed so that it will uses the parent directory of the executing script rather than just using a hardcoded "chiya" value which is rather unnecessarily static.

Removed the legacy comment about registering commands because this seems to be fixed in later versions of Pycord although we plan to switch to discord.py eventually anyways.