### PR TITLE
docker-publish.yml now properly builds to repo

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,42 +4,18 @@ on: [push, pull_request]
 
 env:
   IMAGE_NAME: chiya
+  REPOSITORY: ghcr.io
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Run tests
-        run: |
-          if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run sut
-          else
-            docker build . --file Dockerfile
-          fi
-
-  # Push image to GitHub Packages and docker hub.
-  # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
-    needs: test
-
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-      - name: Prepare
+      - name: Prepare metadata for build
         id: prep
         run: |
-          DOCKER_IMAGE=$(echo ${GITHUB_REPOSITORY} | tr '[A-Z]' '[a-z]')
           VERSION=edge
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
@@ -52,22 +28,13 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
-          TAG="${DOCKER_IMAGE}:${VERSION}"
-          GITHUB_TAG="${DOCKER_IMAGE}/${IMAGE_NAME}:${VERSION}"
           echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tag::${TAG}
-          echo ::set-output name=github-tag::${GITHUB_TAG}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
-      - name: Build image for Github
-        run: docker build . --file Dockerfile --tag ${{ steps.prep.outputs.tag }}
-
-      - name: Log into Github registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Push image to Github packages
-        run: |
-          IMAGE_ID=ghcr.io/${{ steps.prep.outputs.github-tag }}
-
-          docker image tag ${{ steps.prep.outputs.tag }} $IMAGE_ID
-          docker push $IMAGE_ID
+      - name: Build and publish Docker image (using cache)
+        uses: whoan/docker-build-with-cache-action@v5
+        with:
+          registry: ${{env.REPOSITORY}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          image_name: ${{env.IMAGE_NAME}}
+          image_tag: ${{ steps.prep.outputs.version }}


### PR DESCRIPTION
- Fixed name so Docker images are now located under snaacky/chiya:latest instead of snaacky/chiya/chiya:latest.
- Implemented caching to hopefully speed up Docker image builds (cache is located under chiya-stages which is hidden from non-maintainers).
- Simplified bloat in docker-publish.yml because there was a lot of lines that were never used.
- Removed the "test" job which was just a Docker image build that never got pushed anywhere before the actual build occurred because it just increased total build time for no reason.

It seems like performance for this is all over the board, seems mostly out of our control, but I've seen compile times as low as 50s and some ranging around 2-4 minutes, which is a huge improvement over our previous 6-7 minute build times. We can probably tweak this more as time goes on if it needs extra time in the oven.

Using https://github.com/whoan/docker-build-with-cache-action for the caching action.