### PR TITLE
Fixed bug in /pfp with guild avatars.

### DIFF
--- a/chiya/cogs/commands/general.py
+++ b/chiya/cogs/commands/general.py
@@ -39,7 +39,7 @@ class GeneralCommands(commands.Cog):
         await ctx.defer()
 
         user = user or ctx.author
-        user = await self.bot.fetch_user(user.id)
+        user = await ctx.guild.fetch_member(user.id)
         
         embed = embeds.make_embed()
         if server and user.guild_avatar is not None:

--- a/chiya/cogs/commands/general.py
+++ b/chiya/cogs/commands/general.py
@@ -13,14 +13,6 @@ class GeneralCommands(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
-    async def isuser_in_server(self, ctx: context.ApplicationContext, user: discord.User) -> bool:
-        """
-        Check if the user is in the guild where command was invoked.
-        """
-        if ctx.guild.get_member(user.id) is not None:
-            return True
-        else:
-            return False
     
     @slash_command(guild_ids=config["guild_ids"], description="Gets a users profile picture")
     async def pfp(
@@ -50,7 +42,7 @@ class GeneralCommands(commands.Cog):
         user = user or ctx.author 
 
         embed = embeds.make_embed()
-        if await self.isuser_in_server(ctx=ctx,user=user):
+        if ctx.guild.get_member(user.id): #Checks whether user is present in server
             user = await ctx.guild.fetch_member(user.id)
             if server and user.guild_avatar is not None:
                 embed.set_author(icon_url=user.guild_avatar.url, name=str(user))

--- a/chiya/cogs/commands/general.py
+++ b/chiya/cogs/commands/general.py
@@ -13,6 +13,15 @@ class GeneralCommands(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
+    async def isuser_in_server(self, ctx: context.ApplicationContext, user: discord.User) -> bool:
+        """
+        Check if the user is in the guild where command was invoked.
+        """
+        if ctx.guild.get_member(user.id) is not None:
+            return True
+        else:
+            return False
+    
     @slash_command(guild_ids=config["guild_ids"], description="Gets a users profile picture")
     async def pfp(
         self,
@@ -38,20 +47,25 @@ class GeneralCommands(commands.Cog):
         """
         await ctx.defer()
 
-        user = user or ctx.author
-        user = await ctx.guild.fetch_member(user.id)
-        
+        user = user or ctx.author 
+
         embed = embeds.make_embed()
-        if server and user.guild_avatar is not None:
-            embed.set_author(icon_url=user.guild_avatar.url, name=str(user))
-            embed.set_image(url=user.guild_avatar.url)
-        elif server and user.guild_avatar is None:
-            embed.set_author(icon_url=user.display_avatar, name=str(user))
-            embed.set_image(url=user.display_avatar)
-            embed.set_footer(
-                text="⚠️ Prefer server profile picture was specified but user does not have a server profile picture set."
-            )
+        if await self.isuser_in_server(ctx=ctx,user=user):
+            user = await ctx.guild.fetch_member(user.id)
+            if server and user.guild_avatar is not None:
+                embed.set_author(icon_url=user.guild_avatar.url, name=str(user))
+                embed.set_image(url=user.guild_avatar.url)
+            elif server and user.guild_avatar is None:
+                embed.set_author(icon_url=user.display_avatar, name=str(user))
+                embed.set_image(url=user.display_avatar)
+                embed.set_footer(
+                    text="⚠️ Prefer server profile picture was specified but user does not have a server profile picture set."
+                )
+            else:
+                embed.set_author(icon_url=user.display_avatar, name=str(user))
+                embed.set_image(url=user.display_avatar)
         else:
+            user = await self.bot.fetch_user(user.id)
             embed.set_author(icon_url=user.display_avatar, name=str(user))
             embed.set_image(url=user.display_avatar)
         await ctx.send_followup(embed=embed)


### PR DESCRIPTION
Old call fetched [user object](https://docs.pycord.dev/en/master/api.html#id10) from discord, this is not associated with a guild and does not have the guild specific attributes (guild-specific avatar in this case). refer: [fetch_user](https://docs.pycord.dev/en/master/api.html#discord.Client.fetch_user)

New call fetches a [member object](https://docs.pycord.dev/en/master/api.html#discord.Member), which _is_ associated with guilds and includes aforementioned attributes. refer: [fetch_member](https://docs.pycord.dev/en/master/api.html#discord.Guild.fetch_member)