### PR TITLE
Fix /remindme not responding to users with no avatar set

### DIFF
--- a/chiya/utils/embeds.py
+++ b/chiya/utils/embeds.py
@@ -30,7 +30,7 @@ def make_embed(
         embed = discord.Embed(title=title, description=description, color=color)
 
     if ctx and author:
-        embed.set_author(icon_url=ctx.author.avatar.url, name=ctx.author.name)
+        embed.set_author(icon_url=ctx.author.display_avatar, name=ctx.author.name)
 
     if title_url:
         embed.url = title_url


### PR DESCRIPTION
This PR fixes a bug where the remindme command wouldn't respond to users who didn't have an avatar set.

Edit: This PR fixes almost all commands that use `embeds.make_embed()` to generate embeds, that fail due to the command invoker not having a profile picture set.