### PR TITLE
Changed build username to repository owner instead of commit pusher

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
         uses: whoan/docker-build-with-cache-action@v5
         with:
           registry: ${{ env.REPOSITORY }}
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           image_name: ${{ env.IMAGE_NAME }}
           image_tag: ${{ steps.prep.outputs.version }}


### PR DESCRIPTION
`github.actor` was preventing the Docker image from being pushed by anyone other than the repository owner. `github.repository_owner` works with both commits in the main repository as well as on forks.