### PR TITLE
Bumped docker-compose version to 3.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.7"
 services:
   chiya:
     container_name: chiya


### PR DESCRIPTION
Bumped to 3.7 which is the second to latest docker-compose version because Ubuntu 20.04 still does not have 3.8 supported in their package repository.

xoxo munchie