### PR TITLE
Revamp Boosting improve #31

### DIFF
--- a/chiya/cogs/listeners/boost.py
+++ b/chiya/cogs/listeners/boost.py
@@ -16,48 +16,45 @@ class BoostListeners(commands.Cog):
 
     @commands.Cog.listener()
     async def on_member_update(self, before: discord.Member, after: discord.Member) -> None:
-        await self.on_new_booster(before, after)
         await self.on_lost_booster(before, after)
 
     @commands.Cog.listener()
-    async def on_guild_update(self, before: discord.Guild, after: discord.Guild) -> None:
-        await self.on_new_boost(before, after)
+    async def on_message(self, message: discord.Message):
+        if message.type == discord.MessageType.premium_guild_subscription:
+            await self.on_new_boost(message)
 
-    async def on_new_boost(self, before: discord.Guild, after: discord.Guild) -> None:
+    async def on_new_boost(self, message: discord.Message) -> None:
         """
         Send a notification embed when a new boost was received.
         """
-        if after.premium_subscription_count > before.premium_subscription_count:
-            embed = embeds.make_embed(
-                color=discord.Color.nitro_pink(),
-                image_url="https://i.imgur.com/O8R98p9.gif",
-                title="A new booster appeared!",
-                description=(
-                    "Thank you so much for the server boost! "
-                    f"We are now at {after.premium_subscription_count} boosts! "
-                    f"You can contact any <@&{config['roles']['staff']}> member with a "
-                    "[hex color](https://www.google.com/search?q=hex+color) "
-                    "and your desired role name for a custom booster role."
-                ),
-            )
-            await before.system_channel.send(embed=embed)
+        member = message.author
+        guild = message.guild
 
-    async def on_new_booster(self, before: discord.Member, after: discord.Member) -> None:
-        """
-        Send an embed in #nitro-logs when a new boost was received.
-        """
-        if not before.premium_since and after.premium_since:
-            channel = discord.utils.get(after.guild.channels, id=config["channels"]["logs"]["nitro_log"])
-            embed = embeds.make_embed(
-                color=discord.Color.nitro_pink(),
-                title="New booster",
-                description=(
-                    f"{after.mention} boosted the server. "
-                    f"We're now at {after.guild.premium_subscription_count} boosts."
-                ),
-            )
-            await channel.send(embed=embed)
-            log.info(f"{after} boosted {after.guild.name}.")
+        embed = embeds.make_embed(
+            color=discord.Color.nitro_pink(),
+            image_url="https://i.imgur.com/O8R98p9.gif",
+            title="A new booster appeared!",
+            description=(
+                f"{member.mention}, thank you so much for the server boost! "
+                f"We are now at {guild.premium_subscription_count} boosts! "
+                f"You can contact any <@&{config['roles']['staff']}> member with a "
+                "[hex color](https://www.google.com/search?q=hex+color) "
+                "and your desired role name for a custom booster role."
+            ),
+        )
+        boostMsg = await message.channel.send(embed=embed)
+
+        channel = discord.utils.get(guild.channels, id=config["channels"]["logs"]["nitro_log"])
+        embed = embeds.make_embed(
+            color=discord.Color.nitro_pink(),
+            title="New booster",
+            description=(
+                f"{member.mention} [boosted]({boostMsg.jump_url}) the server. "
+                f"We're now at {guild.premium_subscription_count} boosts."
+            ),
+        )
+        await channel.send(embed=embed)
+        log.info(f"{member} boosted {guild.name}.")
 
     async def on_lost_booster(self, before: discord.Member, after: discord.Member) -> None:
         """


### PR DESCRIPTION
- Mentions member who boosted in message.
- Moved log message to same function as general message.
- Added jump link to log boost embed.

I was going to change the message from messaging staff to creating a ticket and mentioning the ticket channel but we don't have config for that. So if add that I can change it to mention the ticket channel.

I tested the message.author on a joining guild message and it returns the member joining so I assume it works the same for boosting