### PR TITLE
Direct booster to tickets instead of staff

### DIFF
--- a/chiya/cogs/listeners/boost.py
+++ b/chiya/cogs/listeners/boost.py
@@ -37,9 +37,9 @@ class BoostListeners(commands.Cog):
             description=(
                 f"{member.mention}, thank you so much for the server boost! "
                 f"We are now at {guild.premium_subscription_count} boosts! "
-                f"You can create a ticket at <#{config['channels']['server']['tickets']}> with a "
-                "[hex color](https://www.google.com/search?q=hex+color) "
-                "and your desired role name and icon for a custom booster role."
+                f"You can create a new ticket in <#{config['channels']['server']['tickets']}> "
+                "with your desired role name, icon (must be transparent), "
+                "and [hex color](https://www.google.com/search?q=hex+color) for a custom booster role."
             ),
         )
         boost_message = await message.channel.send(embed=embed)

--- a/chiya/cogs/listeners/boost.py
+++ b/chiya/cogs/listeners/boost.py
@@ -37,7 +37,7 @@ class BoostListeners(commands.Cog):
             description=(
                 f"{member.mention}, thank you so much for the server boost! "
                 f"We are now at {guild.premium_subscription_count} boosts! "
-                f"You can contact any <@&{config['roles']['staff']}> member with a "
+                f"You can create a ticket at <#{config['channels']['server']['tickets']}> with a "
                 "[hex color](https://www.google.com/search?q=hex+color) "
                 "and your desired role name and icon for a custom booster role."
             ),

--- a/config.default.yml
+++ b/config.default.yml
@@ -41,6 +41,8 @@ channels:
     mute_log: 000000000000000000
     ticket_log: 000000000000000000
     nitro_log: 000000000000000000
+  server:
+    tickets: 000000000000000000
   starboard:
     star_limit: 0
     channel_id: 000000000000000000


### PR DESCRIPTION
Mention the ticket channel instead of the Staff role in the boost embed.

Add Ticket channel to default config.