### PR TITLE
Added discord.HTTPException to moderation command exceptions

### DIFF
--- a/chiya/cogs/commands/ban.py
+++ b/chiya/cogs/commands/ban.py
@@ -92,7 +92,7 @@ class BansCommands(commands.Cog):
 
         try:
             await user.send(embed=dm_embed)
-        except discord.Forbidden:
+        except (discord.Forbidden, discord.HTTPException):
             embed.add_field(
                 name="Notice:",
                 value=(

--- a/chiya/cogs/commands/mute.py
+++ b/chiya/cogs/commands/mute.py
@@ -89,7 +89,7 @@ class MuteCommands(commands.Cog):
 
         try:
             await member.send(embed=dm_embed)
-        except discord.Forbidden:
+        except (discord.Forbidden, discord.HTTPException):
             mute_embed.add_field(
                 name="Notice:",
                 value=(
@@ -168,7 +168,7 @@ class MuteCommands(commands.Cog):
         )
         try:
             await member.send(embed=dm_embed)
-        except discord.Forbidden:
+        except (discord.Forbidden, discord.HTTPException):
             unmute_embed.add_field(
                 name="Notice:",
                 value=(

--- a/chiya/cogs/commands/warn.py
+++ b/chiya/cogs/commands/warn.py
@@ -71,7 +71,7 @@ class WarnCommands(commands.Cog):
                 ],
             )
             await member.send(embed=dm_embed)
-        except discord.Forbidden:
+        except (discord.Forbidden, discord.HTTPException):
             embed.add_field(
                 name="Notice:",
                 value=(

--- a/chiya/cogs/interactions/ticket.py
+++ b/chiya/cogs/interactions/ticket.py
@@ -244,7 +244,7 @@ class TicketCloseButton(discord.ui.View):
                 ],
             )
             await member.send(embed=dm_embed)
-        except discord.Forbidden:
+        except (discord.Forbidden, discord.HTTPException):
             logging.info(f"Unable to send ticket log to {member} because their DM is closed")
 
         ticket["status"] = True


### PR DESCRIPTION
discord.Forbidden doesn't handle every exception such as when a bot is banned, because a bot can't DM another bot, therefore we need to handle discord.HTTPException as well.