### PR TITLE
Removed fetch_user calls when the user object had already fallen back

### DIFF
--- a/chiya/cogs/commands/ban.py
+++ b/chiya/cogs/commands/ban.py
@@ -53,11 +53,8 @@ class BansCommands(commands.Cog):
         """
         await ctx.defer()
 
-        if isinstance(user, discord.Member):
-            if not await can_action_member(ctx=ctx, member=user):
-                return await embeds.error_message(ctx=ctx, description=f"You cannot action {user.mention}.")
-        else:  # TODO: is this really the best way to handle this?
-            user = await self.bot.fetch_user(user)
+        if not await can_action_member(ctx=ctx, member=user):
+            return await embeds.error_message(ctx=ctx, description=f"You cannot action {user.mention}.")
 
         if await self.is_user_banned(ctx=ctx, user=user):
             return await embeds.error_message(ctx=ctx, description=f"{user.mention} is already banned.")
@@ -134,9 +131,6 @@ class BansCommands(commands.Cog):
         with users that it does not share a mutual server with.
         """
         await ctx.defer()
-
-        if not isinstance(user, discord.User):
-            user = await self.bot.fetch_user(user)
 
         if not await self.is_user_banned(ctx=ctx, user=user):
             return await embeds.error_message(ctx=ctx, description=f"{user.mention} is not banned.")

--- a/chiya/cogs/commands/note.py
+++ b/chiya/cogs/commands/note.py
@@ -35,9 +35,6 @@ class NoteCommands(commands.Cog):
         """
         await ctx.defer()
 
-        if not isinstance(user, discord.Member):
-            user = await self.bot.fetch_user(user)
-
         db = database.Database().get()
         note_id = db["mod_logs"].insert(
             dict(
@@ -87,9 +84,6 @@ class NoteCommands(commands.Cog):
         because the output is not hidden.
         """
         await ctx.defer()
-
-        if not isinstance(user, discord.Member):
-            user = await self.bot.fetch_user(user.id)
 
         db = database.Database().get()
         # TODO: can't this be merged into one call because action will return None either way?


### PR DESCRIPTION
- Removed an instance where `fetch_user()` in `commands/ban.py` was called when a user was banned.
- Removed `isinstance()` check before `fetch_user()` call because the instance check is now handled under `can_action_member`.
- Removed `fetch_user()` calls in `commands/note.py` when adding adding a note to a user's profile or when a moderator searched for a user's notes.