### PR TITLE
Bumped pycord version from 2.0.0rc1 to 2.0.0

### DIFF
--- a/chiya/database.py
+++ b/chiya/database.py
@@ -87,5 +87,8 @@ class Database:
             starboard.create_column("message_id", db.types.bigint)
             starboard.create_column("star_embed_id", db.types.bigint)
 
+        for table in db.tables:
+            db.query(f"ALTER TABLE {table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
+
         db.commit()
         db.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ parsedatetime = "2.6"
 PrivateBinAPI = "^1.0.0"
 pyaml_env = "^1.1.3"
 python = "^3.10"
-py-cord = "2.0.0rc1"
+py-cord = "2.0.0"
 requests = "2.28.0"
 sqlalchemy-utils = "0.38.2"
 


### PR DESCRIPTION
Emotes and emojis require the collation to be set to utf8mb4_unicode_ci. This fixes issues with mods being unable to use emotes or emojis in action reasons.