### PR TITLE
Default all tables created by dataset to utf8mb4_unicode_ci

### DIFF
--- a/chiya/database.py
+++ b/chiya/database.py
@@ -87,5 +87,8 @@ class Database:
             starboard.create_column("message_id", db.types.bigint)
             starboard.create_column("star_embed_id", db.types.bigint)
 
+        for table in db.tables:
+            db.query(f"ALTER TABLE {table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
+
         db.commit()
         db.close()


### PR DESCRIPTION
Emotes and emojis require the collation to be set to utf8mb4_unicode_ci. This fixes issues with mods being unable to use emotes or emojis in action reasons.