### PR TITLE
Fixed database collation check so it doesn't run every bot start

### DIFF
--- a/chiya/database.py
+++ b/chiya/database.py
@@ -87,7 +87,14 @@ class Database:
             starboard.create_column("star_embed_id", db.types.bigint)
             log.info("Created missing table: starboard")
 
+        # utf8mb4_unicode_ci is required to support emojis and other unicode.
+        # dataset does not expose collation in any capacity so rather than
+        # checking an object property, we have to do this hacky way of checking
+        # the charset via queries and updating it where necessary.
         for table in db.tables:
+            charset = next(db.query(f"SHOW TABLE STATUS WHERE NAME = '{table}';"))["Collation"]
+            if charset == "utf8mb4_unicode_ci":
+                continue
             db.query(f"ALTER TABLE {table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
             log.info(f"Converted table to utf8mb4_unicode_ci: {table}")
 


### PR DESCRIPTION
Previously, we were setting the collation every time the bot ran which was completely unnecessary because it should never change after the database is initially created. This check will verify the character set at the cost of a few extra queries (which should theoretically cause 0% noticeable impact) and only update the collation when necessary. Annoyingly, dataset does not expose the collation in any capacity despite it being exposed by the underlying SQLAlchemy.