### PR TITLE
Fixed traceback exception that would occur when users DM the bot

### DIFF
--- a/chiya/cogs/listeners/autoresponder.py
+++ b/chiya/cogs/listeners/autoresponder.py
@@ -22,7 +22,12 @@ class AutoresponderListeners(commands.Cog):
         and replies with the appopriate embed. Currently only when invoked
         by a staff member.
         """
+        # Ignore messages from bots to avoid infinite loops and other fuckery.
         if message.author.bot:
+            return
+
+        # Ignore DMs between users and the bot because .roles below will throw an exception.
+        if isinstance(message.channel, discord.channel.DMChannel):
             return
 
         staff = [x for x in message.author.roles


### PR DESCRIPTION
When users sent messages to the bot over DMs, it would throw a traceback because the bot would try to run .roles on the user but seeing as they are in DMs, the message.author is a discord.User and not a discord.Member. This adds a check to prevent that bit of code from executing in the context of DMs.