### PR TITLE
Adjusted tracker status error log level and message

### DIFF
--- a/chiya/utils/trackerstatus.py
+++ b/chiya/utils/trackerstatus.py
@@ -23,8 +23,8 @@ class TrackerStatus():
             r = requests.get(url=self.url)
             r.raise_for_status()
             self.cache_data = r.json()
-        except Exception as e:
-            log.error(e)
+        except Exception:
+            log.debug(f"Unable to refresh {self.tracker} tracker status")
             pass
 
     def get_embed_color(self, embed: discord.Embed):


### PR DESCRIPTION
Previously, by just logging `e`, we were spamming console with upwards of 3-6 lines per error and it would produce a bunch of obnoxious blank newlines.