### PR TITLE
Implemented /hl highlights command

### DIFF
--- a/chiya/cogs/commands/highlight.py
+++ b/chiya/cogs/commands/highlight.py
@@ -1,0 +1,174 @@
+import logging
+
+import discord
+import orjson
+from discord import app_commands
+from discord.ext import commands
+
+
+from chiya import config, database
+from chiya.utils import embeds
+
+
+log = logging.getLogger(__name__)
+
+
+class HighlightCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.guilds(config["guild_id"])
+    @app_commands.guild_only()
+    class HighlightGroup(app_commands.Group):
+        pass
+    highlight = HighlightGroup(name="hl", description="Highlight management commands", guild_ids=[config["guild_id"]])
+
+    @highlight.command(name="create", description="Sets a highlight to be notified when a message is sent in chat")
+    @highlight.describe(message="Reminder message")
+    async def create(
+        self,
+        ctx: discord.Interaction,
+        term: str,
+    ) -> None:
+        """
+        Adds the user to the highlighted term list so they will be notified
+        on subsquent messages containing the highlighted term.
+        """
+        await ctx.response.defer(thinking=True)
+
+        # Prevent /hl list from being extra long and being unable to be sent.
+        if len(term) > 50:
+            return await embeds.error_message(ctx=ctx, description="Highlighted terms must be less than 50 characters.")
+
+        db = database.Database().get()
+
+        # 20 term limit because 20 * 50 = 1000 characters max and embeds are 4096 max.
+        total = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.author.id}%"})]
+        if len(total) >= 20:
+            return await embeds.error_message(
+                ctx=ctx, description="You may only have up to 20 highlighted terms at once."
+            )
+
+        result = db["highlights"].find_one(term={"ilike": term})
+        if result:
+            users = orjson.loads(result["users"])
+            if ctx.author.id not in users:
+                users.append(ctx.author.id)
+                data = dict(id=result["id"], users=orjson.dumps(users))
+                db["highlights"].update(data, ["id"])
+        else:
+            data = dict(term=term, users=orjson.dumps([ctx.author.id]))
+            db["highlights"].insert(data)
+
+        db.commit()
+        db.close()
+
+        embed = embeds.make_embed(
+            ctx=ctx,
+            title="Highlight added",
+            description=f"The term `{term}` was added to your highlights list.",
+            color=discord.Color.green(),
+            author=True,
+        )
+        await ctx.followup.send(embed=embed)
+        highlights = self.bot.get_cog("HighlightsListener")
+        highlights.refresh_highlights()
+
+    @highlight.command(name="list", description="Lists the terms you're currently tracking")
+    async def list_highlights(self, ctx: discord.Interaction) -> None:
+        """
+        Renders a list showing all of the terms that the user currently has
+        highlighted to be notified on usage of.
+        """
+        await ctx.response.defer(thinking=True)
+
+        db = database.Database().get()
+        results = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.author.id}%"})]
+        if not results:
+            return await embeds.error_message(ctx=ctx, description="You are not tracking any terms.")
+
+        embed = embeds.make_embed(
+            ctx=ctx,
+            title="You're currently tracking the following words:",
+            description="\n".join([str(term["term"]) for term in results]),
+            color=discord.Color.green(),
+            author=True,
+        )
+        db.close()
+        await ctx.followup.send(embed=embed)
+
+    @highlight.command(name="remove", description="Remove a term from being tracked")
+    @highlight.describe(message="Term to be removed")
+    async def remove_highlight(
+        self,
+        ctx: discord.Interaction,
+        term: str,
+    ) -> None:
+        await ctx.response.defer(thinking=True)
+
+        db = database.Database().get()
+        result = db["highlights"].find_one(term=term, users={"ilike": f"%{ctx.author.id}%"})
+
+        if not result:
+            return await embeds.error_message(ctx=ctx, description="You are not tracking that term.")
+
+        users = orjson.loads(result["users"])
+        users.remove(ctx.author.id)
+        db["highlights"].update(dict(id=result["id"], users=orjson.dumps(users)), ["id"])
+
+        # Delete the term from the database if no users are tracking the keyword anymore.
+        if not len(users):
+            db["highlights"].delete(term=term)
+
+        db.commit()
+        db.close()
+
+        embed = embeds.make_embed(
+            ctx=ctx,
+            title="Highlight removed",
+            description=f"The term `{term}` was removed from your highlights list.",
+            color=discord.Color.green(),
+            author=True,
+        )
+        await ctx.followup.send(embed=embed)
+        highlights = self.bot.get_cog("HighlightsListener")
+        highlights.refresh_highlights()
+
+    @highlight.command(name="clear", description="Clears all terms being tracked")
+    @highlight.describe(message="Term to be removed")
+    async def clear_highlights(self, ctx: discord.Interaction) -> None:
+        await ctx.response.defer(thinking=True)
+
+        db = database.Database().get()
+        results = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.author.id}%"})]
+
+        if not results:
+            return await embeds.error_message(ctx=ctx, description="You are not tracking any terms.")
+
+        for result in results:
+            users = orjson.loads(result["users"])
+            users.remove(ctx.author.id)
+            db["highlights"].update(dict(id=result["id"], users=orjson.dumps(users)), ["id"])
+
+            # Delete the term from the database if no users are tracking the keyword anymore.
+            if not len(users):
+                db["highlights"].delete(term=result["term"])
+
+        db.commit()
+        db.close()
+        highlights = self.bot.get_cog("HighlightsListener")
+        highlights.refresh_highlights()
+
+        embed = embeds.make_embed(
+            ctx=ctx,
+            title="Highlights cleared",
+            description="All of the terms in your highlight list were cleared.",
+            color=discord.Color.green(),
+            author=True,
+        )
+        await ctx.followup.send(embed=embed)
+
+
+def setup(bot: commands.Bot) -> None:
+    bot.add_cog(HighlightCommands(bot))
+    log.info("Commands loaded: highlights")

--- a/chiya/cogs/commands/highlight.py
+++ b/chiya/cogs/commands/highlight.py
@@ -34,7 +34,7 @@ class HighlightCommands(commands.Cog):
         Adds the user to the highlighted term list so they will be notified
         on subsquent messages containing the highlighted term.
         """
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         # Prevent /hl list from being extra long and being unable to be sent.
         if len(term) > 50:
@@ -80,7 +80,7 @@ class HighlightCommands(commands.Cog):
         Renders a list showing all of the terms that the user currently has
         highlighted to be notified on usage of.
         """
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         db = database.Database().get()
         results = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.user.id}%"})]
@@ -104,7 +104,7 @@ class HighlightCommands(commands.Cog):
         ctx: discord.Interaction,
         term: str,
     ) -> None:
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         db = database.Database().get()
         result = db["highlights"].find_one(term=term, users={"ilike": f"%{ctx.user.id}%"})
@@ -136,7 +136,7 @@ class HighlightCommands(commands.Cog):
 
     @highlight.command(name="clear", description="Clears all terms being tracked")
     async def clear_highlights(self, ctx: discord.Interaction) -> None:
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         db = database.Database().get()
         results = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.user.id}%"})]

--- a/chiya/cogs/commands/highlight.py
+++ b/chiya/cogs/commands/highlight.py
@@ -23,9 +23,9 @@ class HighlightCommands(commands.Cog):
         pass
     highlight = HighlightGroup(name="hl", description="Highlight management commands", guild_ids=[config["guild_id"]])
 
-    @highlight.command(name="create", description="Sets a highlight to be notified when a message is sent in chat")
-    @app_commands.describe(message="Reminder message")
-    async def create(
+    @highlight.command(name="add", description="Adds a term to be tracked")
+    @app_commands.describe(term="Term to be highlighted")
+    async def add_highlight(
         self,
         ctx: discord.Interaction,
         term: str,
@@ -98,7 +98,7 @@ class HighlightCommands(commands.Cog):
         await ctx.followup.send(embed=embed)
 
     @highlight.command(name="remove", description="Remove a term from being tracked")
-    @app_commands.describe(message="Term to be removed")
+    @app_commands.describe(term="Term to be removed")
     async def remove_highlight(
         self,
         ctx: discord.Interaction,
@@ -135,7 +135,6 @@ class HighlightCommands(commands.Cog):
         highlights.refresh_highlights()
 
     @highlight.command(name="clear", description="Clears all terms being tracked")
-    @app_commands.describe(message="Term to be removed")
     async def clear_highlights(self, ctx: discord.Interaction) -> None:
         await ctx.response.defer(thinking=True)
 

--- a/chiya/cogs/commands/highlight.py
+++ b/chiya/cogs/commands/highlight.py
@@ -169,6 +169,6 @@ class HighlightCommands(commands.Cog):
         await ctx.followup.send(embed=embed)
 
 
-def setup(bot: commands.Bot) -> None:
-    bot.add_cog(HighlightCommands(bot))
-    log.info("Commands loaded: highlights")
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(HighlightCommands(bot))
+    log.info("Commands loaded: highlight")

--- a/chiya/cogs/commands/highlight.py
+++ b/chiya/cogs/commands/highlight.py
@@ -24,7 +24,7 @@ class HighlightCommands(commands.Cog):
     highlight = HighlightGroup(name="hl", description="Highlight management commands", guild_ids=[config["guild_id"]])
 
     @highlight.command(name="create", description="Sets a highlight to be notified when a message is sent in chat")
-    @highlight.describe(message="Reminder message")
+    @app_commands.describe(message="Reminder message")
     async def create(
         self,
         ctx: discord.Interaction,
@@ -98,7 +98,7 @@ class HighlightCommands(commands.Cog):
         await ctx.followup.send(embed=embed)
 
     @highlight.command(name="remove", description="Remove a term from being tracked")
-    @highlight.describe(message="Term to be removed")
+    @app_commands.describe(message="Term to be removed")
     async def remove_highlight(
         self,
         ctx: discord.Interaction,
@@ -135,7 +135,7 @@ class HighlightCommands(commands.Cog):
         highlights.refresh_highlights()
 
     @highlight.command(name="clear", description="Clears all terms being tracked")
-    @highlight.describe(message="Term to be removed")
+    @app_commands.describe(message="Term to be removed")
     async def clear_highlights(self, ctx: discord.Interaction) -> None:
         await ctx.response.defer(thinking=True)
 

--- a/chiya/cogs/commands/highlight.py
+++ b/chiya/cogs/commands/highlight.py
@@ -71,7 +71,7 @@ class HighlightCommands(commands.Cog):
             author=True,
         )
         await ctx.followup.send(embed=embed)
-        highlights = self.bot.get_cog("HighlightsListener")
+        highlights = self.bot.get_cog("HighlightListeners")
         highlights.refresh_highlights()
 
     @highlight.command(name="list", description="Lists the terms you're currently tracking")
@@ -131,7 +131,7 @@ class HighlightCommands(commands.Cog):
             author=True,
         )
         await ctx.followup.send(embed=embed)
-        highlights = self.bot.get_cog("HighlightsListener")
+        highlights = self.bot.get_cog("HighlightListeners")
         highlights.refresh_highlights()
 
     @highlight.command(name="clear", description="Clears all terms being tracked")
@@ -155,7 +155,7 @@ class HighlightCommands(commands.Cog):
 
         db.commit()
         db.close()
-        highlights = self.bot.get_cog("HighlightsListener")
+        highlights = self.bot.get_cog("HighlightListeners")
         highlights.refresh_highlights()
 
         embed = embeds.make_embed(

--- a/chiya/cogs/commands/highlight.py
+++ b/chiya/cogs/commands/highlight.py
@@ -43,7 +43,7 @@ class HighlightCommands(commands.Cog):
         db = database.Database().get()
 
         # 20 term limit because 20 * 50 = 1000 characters max and embeds are 4096 max.
-        total = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.author.id}%"})]
+        total = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.user.id}%"})]
         if len(total) >= 20:
             return await embeds.error_message(
                 ctx=ctx, description="You may only have up to 20 highlighted terms at once."
@@ -52,12 +52,12 @@ class HighlightCommands(commands.Cog):
         result = db["highlights"].find_one(term={"ilike": term})
         if result:
             users = orjson.loads(result["users"])
-            if ctx.author.id not in users:
-                users.append(ctx.author.id)
+            if ctx.user.id not in users:
+                users.append(ctx.user.id)
                 data = dict(id=result["id"], users=orjson.dumps(users))
                 db["highlights"].update(data, ["id"])
         else:
-            data = dict(term=term, users=orjson.dumps([ctx.author.id]))
+            data = dict(term=term, users=orjson.dumps([ctx.user.id]))
             db["highlights"].insert(data)
 
         db.commit()
@@ -83,7 +83,7 @@ class HighlightCommands(commands.Cog):
         await ctx.response.defer(thinking=True)
 
         db = database.Database().get()
-        results = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.author.id}%"})]
+        results = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.user.id}%"})]
         if not results:
             return await embeds.error_message(ctx=ctx, description="You are not tracking any terms.")
 
@@ -107,13 +107,13 @@ class HighlightCommands(commands.Cog):
         await ctx.response.defer(thinking=True)
 
         db = database.Database().get()
-        result = db["highlights"].find_one(term=term, users={"ilike": f"%{ctx.author.id}%"})
+        result = db["highlights"].find_one(term=term, users={"ilike": f"%{ctx.user.id}%"})
 
         if not result:
             return await embeds.error_message(ctx=ctx, description="You are not tracking that term.")
 
         users = orjson.loads(result["users"])
-        users.remove(ctx.author.id)
+        users.remove(ctx.user.id)
         db["highlights"].update(dict(id=result["id"], users=orjson.dumps(users)), ["id"])
 
         # Delete the term from the database if no users are tracking the keyword anymore.
@@ -139,14 +139,14 @@ class HighlightCommands(commands.Cog):
         await ctx.response.defer(thinking=True)
 
         db = database.Database().get()
-        results = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.author.id}%"})]
+        results = [result for result in db["highlights"].find(users={"ilike": f"%{ctx.user.id}%"})]
 
         if not results:
             return await embeds.error_message(ctx=ctx, description="You are not tracking any terms.")
 
         for result in results:
             users = orjson.loads(result["users"])
-            users.remove(ctx.author.id)
+            users.remove(ctx.user.id)
             db["highlights"].update(dict(id=result["id"], users=orjson.dumps(users)), ["id"])
 
             # Delete the term from the database if no users are tracking the keyword anymore.

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -61,7 +61,8 @@ class HighlightListeners(commands.Cog):
             chat = ""
             for msg in reversed(messages):
                 chat += f"**[<t:{int(msg.created_at.timestamp())}:T>] {msg.author.name}:** {msg.clean_content[0:256]}\n"
-            chat += f"✨ **[<t:{int(msg.created_at.timestamp())}:T>] {msg.author.name}:** {msg.clean_content[0:256]}\n"
+            chat += f"✨ **[<t:{int(message.created_at.timestamp())}:T>] {message.author.name}:** \
+                {message.clean_content[0:256]}\n"
 
             embed = embeds.make_embed(
                 title=highlight["term"],

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -39,7 +39,7 @@ class HighlightListeners(commands.Cog):
         Checks if the user was active in chat recently.
         """
         after = datetime.datetime.now() - datetime.timedelta(minutes=config["hl"]["timeout"])
-        messages = [message async for message in await channel.history(after=after)]
+        messages = [message async for message in channel.history(after=after)]
         for message in messages:
             return True if message.author == member else False
 

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -57,7 +57,7 @@ class HighlightListeners(commands.Cog):
             if not result:
                 continue
 
-            messages = [message async for message in message.channel.history(limit=4, before=message)]
+            messages = [for_message async for for_message in message.channel.history(limit=4, before=message)]
             chat = ""
             for msg in reversed(messages):
                 chat += f"**[<t:{int(msg.created_at.timestamp())}:T>] {msg.author.name}:** {msg.clean_content[0:256]}\n"

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -39,7 +39,7 @@ class HighlightListeners(commands.Cog):
         Checks if the user was active in chat recently.
         """
         after = datetime.datetime.now() - datetime.timedelta(minutes=config["hl"]["timeout"])
-        messages = await channel.history(after=after).flatten()
+        messages = [message async for message in await channel.history(after=after)]
         for message in messages:
             return True if message.author == member else False
 
@@ -58,7 +58,7 @@ class HighlightListeners(commands.Cog):
             if not result:
                 continue
 
-            messages = await message.channel.history(limit=4, before=message).flatten()
+            messages = [message async for message in message.channel.history(limit=4, before=message)]
             chat = ""
             for msg in reversed(messages):
                 chat += f"**[<t:{int(msg.created_at.timestamp())}:T>] {msg.author.name}:** {msg.clean_content[0:256]}\n"

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -75,7 +75,7 @@ class HighlightListeners(commands.Cog):
                 try:
                     member = await message.guild.fetch_member(subscriber)
                 except discord.errors.NotFound:
-                    log.debug("Attempting to find member failed: " + subscriber)
+                    log.debug(f"Attempting to find member failed: {subscriber}")
                     continue
 
                 if (

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -93,6 +93,6 @@ class HighlightListeners(commands.Cog):
                     pass
 
 
-def setup(bot: commands.Bot) -> None:
-    bot.add_cog(HighlightListeners(bot))
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(HighlightListeners(bot))
     log.info("Listener loaded: highlight")

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -39,9 +39,8 @@ class HighlightListeners(commands.Cog):
         Checks if the user was active in chat recently.
         """
         after = datetime.datetime.now() - datetime.timedelta(minutes=config["hl"]["timeout"])
-        messages = [message async for message in channel.history(after=after)]
-        for message in messages:
-            return True if message.author == member else False
+        message_auths = [message.author.id async for message in channel.history(after=after)]
+        return member.id in message_auths
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
@@ -52,7 +51,7 @@ class HighlightListeners(commands.Cog):
             return
 
         for highlight in self.highlights:
-            regex = rf"\b{highlight['term']}\b"
+            regex = rf"\b{re.escape(highlight['term'])}\b"
             result = re.search(regex, message.clean_content, re.IGNORECASE)
 
             if not result:

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -72,7 +72,12 @@ class HighlightListeners(commands.Cog):
             embed.add_field(name="Source Message", value=f"[Jump to]({message.jump_url})")
 
             for subscriber in highlight["users"]:
-                member = await message.guild.fetch_member(subscriber)
+                try:
+                    member = await message.guild.fetch_member(subscriber)
+                except discord.errors.NotFound:
+                    log.debug("Attempting to find member failed: " + subscriber)
+                    continue
+
                 if (
                     subscriber == message.author.id
                     or not message.channel.permissions_for(member).view_channel

--- a/chiya/cogs/listeners/highlight.py
+++ b/chiya/cogs/listeners/highlight.py
@@ -13,7 +13,7 @@ from chiya.utils import embeds
 log = logging.getLogger(__name__)
 
 
-class HighlightsListener(commands.Cog):
+class HighlightListeners(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self.db = database.Database().get()
@@ -94,5 +94,5 @@ class HighlightsListener(commands.Cog):
 
 
 def setup(bot: commands.Bot) -> None:
-    bot.add_cog(HighlightsListener(bot))
-    log.info("Listener loaded: highlights")
+    bot.add_cog(HighlightListeners(bot))
+    log.info("Listener loaded: highlight")

--- a/chiya/cogs/listeners/highlights.py
+++ b/chiya/cogs/listeners/highlights.py
@@ -1,0 +1,98 @@
+import datetime
+import logging
+import re
+
+import discord
+import orjson
+from discord.ext import commands
+
+from chiya import config, database
+from chiya.utils import embeds
+
+
+log = logging.getLogger(__name__)
+
+
+class HighlightsListener(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.db = database.Database().get()
+        self.highlights = [
+            {
+                "term": highlight["term"],
+                "users": orjson.loads(highlight["users"])
+            }
+            for highlight in self.db["highlights"].find()
+        ]
+
+    def refresh_highlights(self):
+        self.highlights = [
+            {
+                "term": highlight["term"],
+                "users": orjson.loads(highlight["users"])
+            }
+            for highlight in self.db["highlights"].find()
+        ]
+
+    async def is_user_active(self, channel: discord.TextChannel, member: discord.Member) -> bool:
+        """
+        Checks if the user was active in chat recently.
+        """
+        after = datetime.datetime.now() - datetime.timedelta(minutes=config["hl"]["timeout"])
+        messages = await channel.history(after=after).flatten()
+        for message in messages:
+            return True if message.author == member else False
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        """
+        Scan incoming messages for highlights and notify the subscribed users.
+        """
+        if message.author.bot:
+            return
+
+        for highlight in self.highlights:
+            regex = rf"\b{highlight['term']}\b"
+            result = re.search(regex, message.clean_content, re.IGNORECASE)
+
+            if not result:
+                continue
+
+            messages = await message.channel.history(limit=4, before=message).flatten()
+            chat = ""
+            for msg in reversed(messages):
+                chat += f"**[<t:{int(msg.created_at.timestamp())}:T>] {msg.author.name}:** {msg.clean_content[0:256]}\n"
+            chat += f"✨ **[<t:{int(msg.created_at.timestamp())}:T>] {msg.author.name}:** {msg.clean_content[0:256]}\n"
+
+            embed = embeds.make_embed(
+                title=highlight["term"],
+                description=chat,
+                color=discord.Color.gold(),
+            )
+            embed.add_field(name="Source Message", value=f"[Jump to]({message.jump_url})")
+
+            for subscriber in highlight["users"]:
+                member = await message.guild.fetch_member(subscriber)
+                if (
+                    subscriber == message.author.id
+                    or not message.channel.permissions_for(member).view_channel
+                    or await self.is_user_active(message.channel, member)
+                ):
+                    continue
+
+                try:
+                    channel = await member.create_dm()
+                    await channel.send(
+                        embed=embed,
+                        content=(
+                            f"You were mentioned with the highlight term `{highlight['term']}` "
+                            f"in **{message.guild.name}** {message.channel.mention}."
+                        )
+                    )
+                except discord.Forbidden:
+                    pass
+
+
+def setup(bot: commands.Bot) -> None:
+    bot.add_cog(HighlightsListener(bot))
+    log.info("Listener loaded: highlights")

--- a/chiya/cogs/listeners/joyboard.py
+++ b/chiya/cogs/listeners/joyboard.py
@@ -218,11 +218,11 @@ class Joyboard(commands.Cog):
 
         try:
             joyboard_channel = self.bot.get_channel(config["channels"]["joyboard"]["channel_id"])
-            star_embed = await joyboard_channel.fetch_message(result["joy_embed_id"])
+            joy_embed = await joyboard_channel.fetch_message(result["joy_embed_id"])
             db["joyboard"].delete(channel_id=payload.channel_id, message_id=payload.message_id)
             db.commit()
             db.close()
-            await star_embed.delete()
+            await joy_embed.delete()
         except discord.NotFound:
             db.close()
 

--- a/chiya/cogs/listeners/joyboard.py
+++ b/chiya/cogs/listeners/joyboard.py
@@ -1,0 +1,232 @@
+import datetime
+import logging
+import httpx
+
+import discord
+from discord.ext import commands
+
+from urllib.parse import urlparse
+
+from chiya import config, database
+from chiya.utils import embeds
+
+
+log = logging.getLogger(__name__)
+
+
+class Joyboard(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.cache = {"add": set(), "remove": set()}
+
+    def generate_color(self, joy_count: int) -> int:
+        """
+        Hue, saturation, and value is divided by 360, 100, 100 respectively because it is using the fourth coordinate group
+        described in https://en.wikipedia.org/wiki/Wikipedia:WikiProject_Color/Normalized_Color_Coordinates#HSV_coordinates.
+        """
+        if joy_count <= 5:
+            saturation = 0.4
+        elif 6 <= joy_count <= 15:
+            saturation = 0.4 + (joy_count - 5) * 0.06
+        else:
+            saturation = 1
+
+        return discord.Color.from_hsv(48 / 360, saturation, 1).value
+
+    async def get_joy_count(self, message: discord.Message, joys: tuple) -> int:
+        unique_users = set()
+        for reaction in message.reactions:
+            if reaction.emoji not in joys:
+                continue
+
+            async for user in reaction.users():
+                if not user.id == message.author.id:
+                    unique_users.add(user.id)
+
+        return len(unique_users)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        """
+        If a message was reacted with 5 or more joys, send an embed to the joyboard channel, as well as update the joy
+        count in the embed if more joys were reacted.
+
+        Implements a cache to prevent race condition where if multiple joys were reacted on a message after it hits the
+        joy threshold and the IDs were not written to the database quickly enough, a duplicated joy embed would be sent.
+        """
+        joys = ("😂")
+        if payload.emoji.name not in joys:
+            return
+
+        channel = self.bot.get_channel(payload.channel_id)
+        message = await channel.fetch_message(payload.message_id)
+        joy_count = await self.get_joy_count(message, joys)
+        cache_data = (payload.message_id, payload.channel_id)
+
+        if (
+            message.author.bot
+            or message.author.id == payload.member.id
+            or channel.is_nsfw()
+            or payload.channel_id in config["channels"]["joyboard"]["blacklisted"]
+            or joy_count < config["channels"]["joyboard"]["joy_limit"]
+            or cache_data in self.cache["add"]
+        ):
+            return
+
+        self.cache["add"].add(cache_data)
+
+        joyboard_channel = discord.utils.get(message.guild.channels, id=config["channels"]["joyboard"]["channel_id"])
+
+        db = database.Database().get()
+        result = db["joyboard"].find_one(channel_id=payload.channel_id, message_id=payload.message_id)
+
+        if result:
+            try:
+                joy_embed = await joyboard_channel.fetch_message(result["joy_embed_id"])
+                embed_dict = joy_embed.embeds[0].to_dict()
+                embed_dict["color"] = self.generate_color(joy_count=joy_count)
+                embed = discord.Embed.from_dict(embed_dict)
+                self.cache["add"].remove(cache_data)
+                await joy_embed.edit(
+                    content=f"😂 **{joy_count}** {message.channel.mention}",
+                    embed=embed,
+                )
+                return db.close()
+            # Joy embed found in database but the actual joy embed was deleted.
+            except discord.NotFound:
+                pass
+
+        embed = embeds.make_embed(
+            color=self.generate_color(joy_count=joy_count),
+            footer=str(payload.message_id),
+            timestamp=datetime.datetime.now(),
+            fields=[{"name": "Source:", "value": f"[Jump!]({message.jump_url})", "inline": False}],
+        )
+
+        description = f"{message.content}\n\n"
+
+        images = []
+        for attachment in message.attachments:
+            description += f"{attachment.url}\n"
+            # Must be of image MIME type. `content_type` will fail otherwise (NoneType).
+            if "image" in attachment.content_type:
+                images.append(attachment.url)
+
+        for message_embed in message.embeds:
+            # Other types may need to be added in future
+            if message_embed.type in ["gif", "gifv"]:
+                if message_embed.provider and message_embed.provider.url:
+                    urlinfo = urlparse(message_embed.provider.url)
+                    if urlinfo.netloc in ["tenor.com", "tenor.co"]:
+                        async with httpx.AsyncClient() as client:
+                            req = await client.head(f"{message_embed.url}.gif", follow_redirects=True)
+                            images.append(req.url)
+
+        # Prioritize the first image over sticker if possible.
+        if images:
+            embed.set_image(url=images[0])
+        elif message.stickers:
+            embed.set_image(url=message.stickers[0].url)
+
+        embed.description = description
+        embed.set_author(name=message.author.display_name, icon_url=message.author.display_avatar)
+
+        joyed_message = await joyboard_channel.send(
+            content=f"😂 **{joy_count}** {message.channel.mention}",
+            embed=embed,
+        )
+
+        # Update the joy embed ID since the original one was probably deleted.
+        if result:
+            result["joy_embed_id"] = joyed_message.id
+            db["joyboard"].update(result, ["id"])
+        else:
+            data = dict(
+                channel_id=payload.channel_id,
+                message_id=payload.message_id,
+                joy_embed_id=joyed_message.id,
+            )
+            db["joyboard"].insert(data, ["id"])
+
+        db.commit()
+        db.close()
+        self.cache["add"].remove(cache_data)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent) -> None:
+        """
+        Update the joy count in the embed if the joys were reacted. Delete joy embed if the joy count is below threshold.
+        """
+        joys = ("😂")
+        cache_data = (payload.message_id, payload.channel_id)
+
+        if (
+            payload.emoji.name not in joys
+            or cache_data in self.cache["remove"]
+        ):
+            return
+
+        self.cache["remove"].add(cache_data)
+
+        message = await self.bot.get_channel(payload.channel_id).fetch_message(payload.message_id)
+
+        db = database.Database().get()
+        result = db["joyboard"].find_one(channel_id=payload.channel_id, message_id=payload.message_id)
+
+        if not result:
+            self.cache["remove"].remove(cache_data)
+            return db.close()
+
+        joyboard_channel = discord.utils.get(message.guild.channels, id=config["channels"]["joyboard"]["channel_id"])
+
+        try:
+            joy_embed = await joyboard_channel.fetch_message(result["joy_embed_id"])
+        except discord.NotFound:
+            self.cache["remove"].remove(cache_data)
+            return db.close()
+
+        joy_count = await self.get_joy_count(message, joys)
+
+        if joy_count < config["channels"]["joyboard"]["joy_limit"]:
+            db["joyboard"].delete(channel_id=payload.channel_id, message_id=payload.message_id)
+            db.commit()
+            db.close()
+            self.cache["remove"].remove(cache_data)
+            return await joy_embed.delete()
+
+        embed_dict = joy_embed.embeds[0].to_dict()
+        embed_dict["color"] = self.generate_color(joy_count=joy_count)
+        embed = discord.Embed.from_dict(embed_dict)
+        await joy_embed.edit(
+            content=f"😂 **{joy_count}** {message.channel.mention}",
+            embed=embed,
+        )
+
+        db.close()
+        self.cache["remove"].remove(cache_data)
+
+    @commands.Cog.listener()
+    async def on_raw_message_delete(self, payload):
+        """
+        Automatically remove the joyboard embed if the message linked to it is deleted.
+        """
+        db = database.Database().get()
+        result = db["joyboard"].find_one(channel_id=payload.channel_id, message_id=payload.message_id)
+
+        if not result:
+            return db.close()
+
+        try:
+            joyboard_channel = self.bot.get_channel(config["channels"]["joyboard"]["channel_id"])
+            star_embed = await joyboard_channel.fetch_message(result["joy_embed_id"])
+            db["joyboard"].delete(channel_id=payload.channel_id, message_id=payload.message_id)
+            db.commit()
+            db.close()
+            await star_embed.delete()
+        except discord.NotFound:
+            db.close()
+
+
+async def setup(bot: commands.bot.Bot) -> None:
+    await bot.add_cog(Joyboard(bot))
+    log.info("Listener loaded: joyboard")

--- a/chiya/cogs/listeners/joyboard.py
+++ b/chiya/cogs/listeners/joyboard.py
@@ -54,7 +54,7 @@ class Joyboard(commands.Cog):
         Implements a cache to prevent race condition where if multiple joys were reacted on a message after it hits the
         joy threshold and the IDs were not written to the database quickly enough, a duplicated joy embed would be sent.
         """
-        joys = ("😂")
+        joys = ("😂",)
         if payload.emoji.name not in joys:
             return
 
@@ -157,7 +157,7 @@ class Joyboard(commands.Cog):
         """
         Update the joy count in the embed if the joys were reacted. Delete joy embed if the joy count is below threshold.
         """
-        joys = ("😂")
+        joys = ("😂",)
         cache_data = (payload.message_id, payload.channel_id)
 
         if (

--- a/chiya/database.py
+++ b/chiya/database.py
@@ -94,6 +94,12 @@ class Database:
             joyboard.create_column("joy_embed_id", db.types.bigint)
             log.info("Created missing table: joyboard")
 
+        if "highlights" not in db:
+            highlights = db.create_table("highlights")
+            highlights.create_column("term", db.types.text)
+            highlights.create_column("users", db.types.text)
+            log.info("Created missing table: highlights")
+
         for table in db.tables:
             db.query(f"ALTER TABLE {table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
             log.info(f"Converted table to utf8mb4_unicode_ci: {table}")

--- a/chiya/database.py
+++ b/chiya/database.py
@@ -87,6 +87,13 @@ class Database:
             starboard.create_column("star_embed_id", db.types.bigint)
             log.info("Created missing table: starboard")
 
+        if "joyboard" not in db:
+            joyboard = db.create_table("joyboard")
+            joyboard.create_column("channel_id", db.types.bigint)
+            joyboard.create_column("message_id", db.types.bigint)
+            joyboard.create_column("joy_embed_id", db.types.bigint)
+            log.info("Created missing table: joyboard")
+
         for table in db.tables:
             db.query(f"ALTER TABLE {table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
             log.info(f"Converted table to utf8mb4_unicode_ci: {table}")


### PR DESCRIPTION
This is an implementation of the Carl-bot highlights system that is no longer publicly available in their bot. Highlights will notify a user when a highlighted term is sent in chat if they have access to the channel that the message was sent in and if they haven't spoken in the channel in >5 minutes.

`/hl add` - Adds a term to be tracked
`/hl list` - Lists the terms you're currently tracking
`/hl clear` - Clears all terms being tracked
`/hl remove` - Removes a term from being tracked