### PR TITLE
refactor: remove nsfw channel check from joyboard

### DIFF
--- a/chiya/cogs/listeners/joyboard.py
+++ b/chiya/cogs/listeners/joyboard.py
@@ -91,7 +91,6 @@ class Joyboard(commands.Cog):
                 if (
                     message.author.bot
                     or message.author.id == payload.member.id
-                    or channel.is_nsfw()
                     or payload.channel_id in config["channels"]["joyboard"]["blacklisted"]
                     or joy_count < config["channels"]["joyboard"]["joy_limit"]
                 ):
@@ -193,7 +192,6 @@ class Joyboard(commands.Cog):
         channel = self.bot.get_channel(payload.channel_id)
 
         if (
-            channel.is_nsfw()
             or payload.channel_id in config["channels"]["joyboard"]["blacklisted"]
         ):
             return

--- a/chiya/cogs/listeners/joyboard.py
+++ b/chiya/cogs/listeners/joyboard.py
@@ -191,9 +191,7 @@ class Joyboard(commands.Cog):
 
         channel = self.bot.get_channel(payload.channel_id)
 
-        if (
-            payload.channel_id in config["channels"]["joyboard"]["blacklisted"]
-        ):
+        if payload.channel_id in config["channels"]["joyboard"]["blacklisted"]:
             return
 
         self.reactions[payload.message_id] = payload

--- a/chiya/cogs/listeners/joyboard.py
+++ b/chiya/cogs/listeners/joyboard.py
@@ -192,7 +192,7 @@ class Joyboard(commands.Cog):
         channel = self.bot.get_channel(payload.channel_id)
 
         if (
-            or payload.channel_id in config["channels"]["joyboard"]["blacklisted"]
+            payload.channel_id in config["channels"]["joyboard"]["blacklisted"]
         ):
             return
 


### PR DESCRIPTION
This PR removes the NSFW channel check from joyboard, allowing messages from NSFW channels to be joyboarded.