### PR TITLE
Mod actions are now ephemeral and logged to a channel, misc. changes 

### DIFF
--- a/chiya/cogs/commands/administration.py
+++ b/chiya/cogs/commands/administration.py
@@ -18,18 +18,6 @@ log = logging.getLogger(__name__)
 
 
 class AdministrationCommands(Cog):
-    """
-    This class is legacy code that needs to eventually be
-    split into separate files and removed from the codebase.
-
-    The eval command cannot be ported to slash commands until Discord
-    supports slash command parameters with multiple lines of input.
-
-    We will eventually migrate the embed generators into a slash
-    command based embed generator system where the embed generators
-    below will be stored as presets that can be spawned via slash
-    commands.
-    """
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
@@ -37,16 +25,14 @@ class AdministrationCommands(Cog):
         self._last_result = None
         self.bot.tree.add_command(self.eval_command)
 
-    def app_is_owner(self, interaction: discord.Interaction, *kwargs):
-        return self.bot.is_owner(interaction.user)
+    def app_is_owner(self, ctx: discord.Interaction, *kwargs):
+        return self.bot.is_owner(ctx.user)
 
     @app_commands.check(app_is_owner)
     class AdminGroup(app_commands.Group):
         pass
-    admin = AdminGroup(name="admin", description="Admin commands", guild_ids=[config["guild_id"]])
-
-    embed = AdminGroup(name="embed", description="Embed creation commands", parent=admin)
-    sync = AdminGroup(name="sync", description="Sync commands", parent=admin)
+    admin = AdminGroup(name="admin", guild_ids=[config["guild_id"]])
+    sync = AdminGroup(name="sync", parent=admin)
 
     def _cleanup_code(self, content: str) -> str:
         """
@@ -147,157 +133,53 @@ class AdministrationCommands(Cog):
                 embed.add_field(name="Output:", value=output, inline=False)
                 await ctx.followup.send(embed=embed)
 
-
-    #[[
-    # EMBED COMMANDS
-    # ]]
-
-    @embed.command(name="rules", description="Sends rule message to channel")
-    async def rules(self, ctx: discord.Interaction) -> None:
-        """Generates the #rules channel embeds."""
-        await ctx.response.defer(ephemeral=True,thinking=True)
-
-        embed = embeds.make_embed(color=0x7D98E9)
-        embed.set_image(
-            url="https://cdn.discordapp.com/attachments/835088653981581312/902441305836244992/AnimePiracy-Aqua-v2-Revision5.7.png"
-        )
-        await ctx.channel.send(embed=embed)
-
-        embed = embeds.make_embed(
-            description=(
-                "**1. Do not share copyright infringing files or links**\n"
-                "Sharing illegal streaming sites, downloads, torrents, magnet links, trackers, NZBs, or any other form of warez puts our community at risk of being shut down. We are a discussion community, not a file-sharing hub.\n\n"
-                "**2. Treat others the way you want to be treated**\n"
-                "Attacking, belittling, or instigating drama with others will result in your removal from the community. Any form of prejudice, including but not limited to race, religion, gender, sexual identity, or ethnic background, will not be tolerated.\n\n"
-                "**3. Do not disrupt chat**\n"
-                "Avoid spamming, derailing conversations, trolling, posting in the incorrect channel, or disregarding channel rules. We expect you to make a basic attempt to fit in and not cause problems.\n\n"
-                "**4. Do not abuse pings**\n"
-                "Attempting to mass ping, spam ping, ghost ping, or harassing users with pings is not allowed. VIPs should not be pinged for help with their service. <@&763031634379276308> should only be pinged when the situation calls for their immediate attention.\n\n"
-                "**5. Do not attempt to evade mod actions**\n"
-                "Abusing the rules, such as our automod system, will not be tolerated. Subsequently, trying to find loopholes in the rules to evade mod action is not allowed and will result in a permanent ban.\n\n"
-                "**6. Do not post unmarked spoilers**\n"
-                "Be considerate and [use spoiler tags](https://support.discord.com/hc/en-us/articles/360022320632-Spoiler-Tags-) when discussing plot elements. Specify which title, series, or episode your spoiler is referencing outside the spoiler tag so that people don't blindly click a spoiler.\n\n"
-                "**7. All conversation must be in English**\n"
-                "No language other than English is permitted. We appreciate other languages and cultures, but we can only moderate the content we understand.\n\n"
-                "**8. Do not post self-promotional content**\n"
-                "We are not a billboard for you to advertise your Discord server, social media channels, referral links, personal projects, or services. Unsolicited spam via DMs will result in an immediate ban.\n\n"
-                "**9. One account per person per lifetime**\n"
-                "Anyone found sharing or using alternate accounts will be banned. Contact staff if you feel you deserve an exception.\n\n"
-                "**10. Do not give away, trade, or misuse invites**\n"
-                "Invites are intended for personal acquaintances. Publicly offering, requesting, or giving away invites to private trackers, DDL communities, or Usenet indexers is not allowed.\n\n"
-                "**11. Do not post NSFL content**\n"
-                'NSFL content is described as "content which is so nauseating or disturbing that it might be emotionally scarring to view." Content marked NSFL may contain fetish pornography, gore, or lethal violence.\n\n'
-                "**12. Egregious profiles are not allowed**\n"
-                "Users with excessively offensive usernames, nicknames, avatars, server profiles, or statuses may be asked to change the offending content or may be preemptively banned in more severe cases."
-            ),
-            color=0x7D98E9,
-        )
-
-        await ctx.channel.send(embed=embed)
-        await ctx.followup.send("Rules added!", ephemeral=True)
-
-    @embed.command(name="colorroles", description="Create the color roles embed message")
-    async def create_color_roles_embed(self, ctx: discord.Interaction) -> None:
-        await ctx.response.defer(ephemeral=True,thinking=True)
-        embed = discord.Embed(
-            description=(
-                "You can react to one of the squares below to be assigned a colored user role. "
-                f"If you are interested in a different color, you can become a <@&{config['roles']['nitro_booster']}> "
-                "to receive a custom colored role."
-            )
-        )
-
-        msg = await ctx.channel.send(embed=embed)
-
-        # API call to fetch all the emojis to cache, so that they work in future calls
-        emotes_guild = await self.bot.fetch_guild((config["emoji_guild_ids"][0]))
-        await emotes_guild.fetch_emojis()
-
-        await msg.add_reaction(":redsquare:805032092907601952")
-        await msg.add_reaction(":orangesquare:805032107952308235")
-        await msg.add_reaction(":yellowsquare:805032120971165709")
-        await msg.add_reaction(":greensquare:805032132325801994")
-        await msg.add_reaction(":bluesquare:805032145030348840")
-        await msg.add_reaction(":pinksquare:805032162197635114")
-        await msg.add_reaction(":purplesquare:805032172074696744")
-        await ctx.followup.send("Color messaged sent!", ephemeral=True)
-
-    @embed.command(name="reactroles", description="Create the assignable roles embed message")
-    async def create_assignable_roles_embed(self, ctx: discord.Interaction) -> None:
-        await ctx.response.defer(ephemeral=True,thinking=True)
-        role_assignment_text = """
-        You can react to one of the emotes below to assign yourself an event role.
-
-        🎁  <@&832528733763928094> - Receive giveaway pings.
-        📢  <@&827611682917711952> - Receive server announcement pings.
-        📽  <@&831999443220955136> - Receive group watch event pings.
-        <:kakeraW:830594599001129000>  <@&832512304334766110> - Receive Mudae event and season pings.
-        🧩  <@&832512320306675722> - Receive Rin event pings.
-        """
-        embed = discord.Embed(description=role_assignment_text)
-        msg = await ctx.channel.send(embed=embed)
-
-        # API call to fetch all the emojis to cache, so that they work in future calls
-        emotes_guild = await ctx.client.fetch_guild(config["emoji_guild_ids"][0])
-        await emotes_guild.fetch_emojis()
-
-        await msg.add_reaction("🎁")
-        await msg.add_reaction("📢")
-        await msg.add_reaction("📽")
-        await msg.add_reaction(":kakeraW:830594599001129000")
-        await msg.add_reaction("🧩")
-        await ctx.followup.send("Rules added!", ephemeral=True)
-
-    #[[
-    # SYNC COMMANDS
-    # ]]
-
-    @sync.command(name="global", description="Sync commands globally.")    
-    async def sync_global(self, interaction: discord.Interaction) -> None:
+    @sync.command(name="global", description="Sync commands globally.")
+    async def sync_global(self, ctx: discord.Interaction) -> None:
         """
         Does not sync all commands globally, just the ones registered as global.
         """
-        await interaction.response.defer()
+        await ctx.response.defer()
         synced = await self.bot.tree.sync()
-        await embeds.success_message(ctx=interaction, description=f"Synced {len(synced)} commands globally.")
+        await embeds.success_message(ctx=ctx, description=f"Synced {len(synced)} commands globally.")
 
     @sync.command(name="guild", description="Sync commands in the current guild")
-    async def sync_guild(self, interaction: discord.Interaction) -> None:
+    async def sync_guild(self, ctx: discord.Interaction) -> None:
         """
         Does not sync all of your commands to that guild, just the ones registered to that guild.
         """
-        await interaction.response.defer()
-        synced = await self.bot.tree.sync(guild=interaction.guild)
-        await embeds.success_message(ctx=interaction, description=f"Synced {len(synced)} commands to the current guild.")
+        await ctx.response.defer()
+        synced = await self.bot.tree.sync(guild=ctx.guild)
+        await embeds.success_message(ctx=ctx, description=f"Synced {len(synced)} commands to the guild.")
 
     @sync.command(name="copy", description="Copies all global app commands to current guild and syncs")
-    async def sync_global_to_guild(self, interaction: discord.Interaction) -> None:
+    async def sync_global_to_guild(self, ctx: discord.Interaction) -> None:
         """
         This will copy the global list of commands in the tree into the list of commands for the specified guild.
-        This is not permanent between bot restarts, and it doesn't impact the state of the commands (you still have to sync).
+        This is not permanent between bot restarts.
         """
-        await interaction.response.defer()
-        self.bot.tree.copy_global_to(guild=interaction.guild)
-        synced = await self.bot.tree.sync(guild=interaction.guild)
-        await embeds.success_message(ctx=interaction, description=f"Copied and synced {len(synced)} global app commands to the current guild.")
+        await ctx.response.defer()
+        self.bot.tree.copy_global_to(guild=ctx.guild)
+        synced = await self.bot.tree.sync(guild=ctx.guild)
+        await embeds.success_message(ctx=ctx, description=f"Synced {len(synced)} global commands to the current guild.")
 
     @sync.command(name="remove", description="Clears all commands from the current guild target and syncs")
-    async def sync_remove(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer()
-        self.bot.tree.clear_commands(guild=interaction.guild)
-        await self.bot.tree.sync(guild=interaction.guild)
-        await embeds.success_message(ctx=interaction, description="Cleared all commands from the current guild and synced.")
+    async def sync_remove(self, ctx: discord.Interaction) -> None:
+        await ctx.response.defer()
+        self.bot.tree.clear_commands(guild=ctx.guild)
+        await self.bot.tree.sync(guild=ctx.guild)
+        await embeds.success_message(ctx=ctx, description="Cleared all commands from the current guild and synced.")
 
     @sync_global.error
     @sync_guild.error
     @sync_global_to_guild.error
     @sync_remove.error
-    async def sync_error(self, interaction: discord.Interaction, error: discord.HTTPException) -> None:
-        await interaction.response.defer()
+    async def sync_error(self, ctx: discord.Interaction, error: discord.HTTPException) -> None:
+        await ctx.response.defer()
 
         if isinstance(error, discord.app_commands.errors.MissingRole):
-            embed = embeds.error_embed(ctx=interaction, description=f"Role <@&{error.missing_role}> is required to use this command.")
-            await interaction.followup.send(embed=embed)
+            embed = embeds.error_embed(ctx=ctx, description=f"<@&{error.missing_role}> is required for this command.")
+            await ctx.followup.send(embed=embed)
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(AdministrationCommands(bot))

--- a/chiya/cogs/commands/ban.py
+++ b/chiya/cogs/commands/ban.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 
 from chiya import config, database
 from chiya.utils import embeds
-from chiya.utils.helpers import can_action_member
+from chiya.utils.helpers import can_action_member, log_embed_to_channel
 
 
 log = logging.getLogger(__name__)
@@ -18,9 +18,7 @@ class BansCommands(commands.Cog):
         self.bot = bot
 
     async def is_user_banned(self, ctx: discord.Interaction, user: discord.Member | discord.User) -> bool:
-        """
-        Check if the user is banned from the context invoking guild.
-        """
+        """Check if the user is banned from the context guild."""
         try:
             return bool(await self.bot.get_guild(ctx.guild.id).fetch_ban(user))
         except discord.NotFound:
@@ -41,7 +39,7 @@ class BansCommands(commands.Cog):
     ) -> None:
         """
         Ban the user, log the action to the database, and attempt to send them
-        a direct message alerting them of their ban.
+        a direct message notfying them of their ban.
 
         If the user isn't in the server, has privacy settings enabled, or has
         the bot blocked they will be unable to receive the ban notification.
@@ -50,9 +48,9 @@ class BansCommands(commands.Cog):
         daystodelete is limited to a maximum value of 7. This is a Discord API
         limitation with the .ban() function.
         """
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
-        if not await can_action_member(ctx=ctx, member=user):
+        if not can_action_member(ctx=ctx, member=user):
             return await embeds.error_message(ctx=ctx, description=f"You cannot action {user.mention}.")
 
         if await self.is_user_banned(ctx=ctx, user=user):
@@ -61,7 +59,7 @@ class BansCommands(commands.Cog):
         if len(reason) > 1024:
             return await embeds.error_message(ctx=ctx, description="Reason must be less than 1024 characters.")
 
-        embed = embeds.make_embed(
+        mod_embed = embeds.make_embed(
             ctx=ctx,
             author=True,
             title=f"Banning user: {user}",
@@ -70,7 +68,7 @@ class BansCommands(commands.Cog):
             color=discord.Color.red(),
         )
 
-        dm_embed = embeds.make_embed(
+        user_embed = embeds.make_embed(
             author=False,
             title="Uh-oh, you've been banned!",
             description=(
@@ -86,9 +84,9 @@ class BansCommands(commands.Cog):
         )
 
         try:
-            await user.send(embed=dm_embed)
+            await user.send(embed=user_embed)
         except (discord.Forbidden, discord.HTTPException):
-            embed.add_field(
+            mod_embed.add_field(
                 name="Notice:",
                 value=(
                     f"Unable to message {user.mention} about this action. "
@@ -110,8 +108,9 @@ class BansCommands(commands.Cog):
         db.commit()
         db.close()
 
-        await ctx.guild.ban(user, reason=reason, delete_message_days=daystodelete or 0)
-        await ctx.followup.send(embed=embed)
+        await ctx.guild.ban(user=user, reason=reason, delete_message_days=daystodelete or 0)
+        await log_embed_to_channel(ctx=ctx, embed=mod_embed)
+        await ctx.followup.send(embed=mod_embed)
 
     @app_commands.command(name="unban", description="Unban user from the server")
     @app_commands.guilds(config["guild_id"])
@@ -126,7 +125,7 @@ class BansCommands(commands.Cog):
         the user know that they were unbanned because it cannot communicate
         with users that it does not share a mutual server with.
         """
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         if not await self.is_user_banned(ctx=ctx, user=user):
             return await embeds.error_message(ctx=ctx, description=f"{user.mention} is not banned.")
@@ -134,7 +133,7 @@ class BansCommands(commands.Cog):
         if len(reason) > 1024:
             return await embeds.error_message(ctx=ctx, description="Reason must be less than 1024 characters.")
 
-        embed = embeds.make_embed(
+        mod_embed = embeds.make_embed(
             ctx=ctx,
             author=True,
             title=f"Unbanning user: {user}",
@@ -151,7 +150,8 @@ class BansCommands(commands.Cog):
         db.close()
 
         await ctx.guild.unban(user, reason=reason)
-        await ctx.followup.send(embed=embed)
+        await log_embed_to_channel(ctx=ctx, embed=mod_embed)
+        await ctx.followup.send(embed=mod_embed)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/chiya/cogs/commands/general.py
+++ b/chiya/cogs/commands/general.py
@@ -25,15 +25,8 @@ class GeneralCommands(commands.Cog):
         user: discord.Member | discord.User = None,
         profile: bool = None
     ) -> None:
-        """
-        Grab a user's avatar and return it in a large-sized embed.
-
-        If the user parameter is not specified, the function will grab the
-        invokers avatar instead. Offers the ability to attempt to grab a users
-        server avatar and will fallback to their global avatar with a warning
-        attached if a server specific avatar is not set.
-        """
-        await ctx.response.defer(thinking=True)
+        """Send an embed with the specified users avatar."""
+        await ctx.response.defer(thinking=True, ephemeral=True)
         user = user or ctx.user
         embed = embeds.make_embed()
         if profile and isinstance(user, discord.Member):

--- a/chiya/cogs/commands/mute.py
+++ b/chiya/cogs/commands/mute.py
@@ -153,7 +153,7 @@ class MuteCommands(commands.Cog):
         if len(reason) > 1024:
             return await embeds.error_message(ctx=ctx, description="Reason must be less than 1024 characters.")
 
-        user_embed = embeds.make_embed(
+        mod_embed = embeds.make_embed(
             ctx=ctx,
             title=f"Unmuting member: {member.name}",
             description=f"{member.mention} was unmuted by {ctx.user.mention} for: {reason}",
@@ -161,7 +161,7 @@ class MuteCommands(commands.Cog):
             thumbnail_url="https://i.imgur.com/W7DpUHC.png",
         )
 
-        mod_embed = embeds.make_embed(
+        user_embed = embeds.make_embed(
             author=False,
             title="Yay, you've been unmuted!",
             description="Review our server rules to avoid being actioned again in the future.",

--- a/chiya/cogs/commands/mute.py
+++ b/chiya/cogs/commands/mute.py
@@ -8,7 +8,7 @@ from discord import app_commands
 
 from chiya import config, database
 from chiya.utils import embeds
-from chiya.utils.helpers import can_action_member, get_duration
+from chiya.utils.helpers import can_action_member, get_duration, log_embed_to_channel
 
 
 log = logging.getLogger(__name__)
@@ -40,12 +40,12 @@ class MuteCommands(commands.Cog):
         notification. The bot will let the invoking mod know if this
         is the case.
         """
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         if not isinstance(member, discord.Member):
             return await embeds.error_message(ctx=ctx, description="That user is not in the server.")
 
-        if not await can_action_member(ctx=ctx, member=member):
+        if not can_action_member(ctx=ctx, member=member):
             return await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
 
         if member.is_timed_out():
@@ -69,7 +69,7 @@ class MuteCommands(commands.Cog):
         if time_delta >= 2419200:
             return await embeds.error_message(ctx=ctx, description="Timeout duration cannot exceed 28 days.")
 
-        mute_embed = embeds.make_embed(
+        mod_embed = embeds.make_embed(
             ctx=ctx,
             title=f"Muting member: {member}",
             description=f"{member.mention} was muted by {ctx.user.mention} for: {reason}",
@@ -78,7 +78,7 @@ class MuteCommands(commands.Cog):
             fields=[{"name": "Duration:", "value": duration_string, "inline": False}],
         )
 
-        dm_embed = embeds.make_embed(
+        user_embed = embeds.make_embed(
             title="Uh-oh, you've been muted!",
             description="If you believe this was a mistake, contact staff.",
             image_url="https://i.imgur.com/840Q48l.gif",
@@ -91,9 +91,9 @@ class MuteCommands(commands.Cog):
         )
 
         try:
-            await member.send(embed=dm_embed)
+            await member.send(embed=user_embed)
         except (discord.Forbidden, discord.HTTPException):
-            mute_embed.add_field(
+            mod_embed.add_field(
                 name="Notice:",
                 value=(
                     f"Unable to message {member.mention} about this action. "
@@ -117,7 +117,8 @@ class MuteCommands(commands.Cog):
         db.close()
 
         await member.timeout(datetime.fromtimestamp(mute_end_time, timezone.utc), reason=reason)
-        await ctx.followup.send(embed=mute_embed)
+        await log_embed_to_channel(ctx=ctx, embed=mod_embed)
+        await ctx.followup.send(embed=mod_embed)
 
     @app_commands.command(name="unmute", description="Umutes a member in the server")
     @app_commands.guilds(config["guild_id"])
@@ -138,12 +139,12 @@ class MuteCommands(commands.Cog):
         will be unable to receive the ban notification. The bot will let the
         invoking mod know if this is the case.
         """
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         if not isinstance(member, discord.Member):
             return await embeds.error_message(ctx=ctx, description="That user is not in the server.")
 
-        if not await can_action_member(ctx=ctx, member=member):
+        if not can_action_member(ctx=ctx, member=member):
             return await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
 
         if not member.is_timed_out():
@@ -152,7 +153,7 @@ class MuteCommands(commands.Cog):
         if len(reason) > 1024:
             return await embeds.error_message(ctx=ctx, description="Reason must be less than 1024 characters.")
 
-        unmute_embed = embeds.make_embed(
+        user_embed = embeds.make_embed(
             ctx=ctx,
             title=f"Unmuting member: {member.name}",
             description=f"{member.mention} was unmuted by {ctx.user.mention} for: {reason}",
@@ -160,7 +161,7 @@ class MuteCommands(commands.Cog):
             thumbnail_url="https://i.imgur.com/W7DpUHC.png",
         )
 
-        dm_embed = embeds.make_embed(
+        mod_embed = embeds.make_embed(
             author=False,
             title="Yay, you've been unmuted!",
             description="Review our server rules to avoid being actioned again in the future.",
@@ -173,9 +174,9 @@ class MuteCommands(commands.Cog):
             ],
         )
         try:
-            await member.send(embed=dm_embed)
+            await member.send(embed=user_embed)
         except (discord.Forbidden, discord.HTTPException):
-            unmute_embed.add_field(
+            mod_embed.add_field(
                 name="Notice:",
                 value=(
                     f"Unable to message {member.mention} about this action. "
@@ -197,8 +198,9 @@ class MuteCommands(commands.Cog):
         db.commit()
         db.close()
 
-        await member.timeout(None, reason=reason)
-        await ctx.followup.send(embed=unmute_embed)
+        await member.timeout(until=None, reason=reason)
+        await log_embed_to_channel(ctx=ctx, embed=mod_embed)
+        await ctx.followup.send(embed=mod_embed)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/chiya/cogs/commands/note.py
+++ b/chiya/cogs/commands/note.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 
 from chiya import config, database
 from chiya.utils import embeds
+from chiya.utils.helpers import log_embed_to_channel
 from chiya.utils.pagination import LinePaginator
 
 
@@ -25,14 +26,8 @@ class NoteCommands(commands.Cog):
     @app_commands.describe(user="The user to add the note to")
     @app_commands.describe(note="The note to leave on the user")
     async def add_note(self, ctx: discord.Interaction, user: discord.Member | discord.User, note: str) -> None:
-        """
-        Adds a note to the users profile.
-
-        Notes can only be seen by staff via the /search command and do not
-        punish the user in anyway. They are merely for staff to log relevant
-        information. Users are not alerted when a note is added to them.
-        """
-        await ctx.response.defer(thinking=True)
+        """Adds a note to the specified user queryable via /search."""
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         db = database.Database().get()
         note_id = db["mod_logs"].insert(
@@ -58,6 +53,7 @@ class NoteCommands(commands.Cog):
             ],
         )
 
+        await log_embed_to_channel(ctx=ctx, embed=embed)
         await ctx.followup.send(embed=embed)
 
     @app_commands.command(name="search", description="Search through a users notes and mod logs")
@@ -73,24 +69,10 @@ class NoteCommands(commands.Cog):
     ) -> None:
         """
         Search for the mod actions and notes for a user. The search can be
-        filtered by ban, unban, unmute, warn, or notes.
-
-        Users are not alerted when they have a /search command ran on them.
-        Only the command invoking user can change pages on the pagination.
-        It is imperative that the command is not ran in public channels
-        because the output is not hidden.
-
-        TODO: Bug that occurs when running /search:
-            Traceback (most recent call last):
-            File "virtualenvs\\chiya-Z7ITmrUJ-py3.10\\lib\\site-packages\\sqlalchemy\\engine\\base.py", line 1995, in _safe_close_cursor
-                cursor.close()
-            File "virtualenvs\\chiya-Z7ITmrUJ-py3.10\\lib\\site-packages\\MySQLdb\\cursors.py", line 83, in close
-                while self.nextset():
-            File "virtualenvs\\chiya-Z7ITmrUJ-py3.10\\lib\\site-packages\\MySQLdb\\\cursors.py", line 137, in nextset
-                nr = db.next_result()
-            MySQLdb.OperationalError: (2006, '')
+        filtered by ban, unban, unmute, warn, or notes. Users are not alerted
+        when they have a /search command ran on them.
         """
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         db = database.Database().get()
         # TODO: can't this be merged into one call because action will return None either way?
@@ -111,11 +93,7 @@ class NoteCommands(commands.Cog):
                 "note": "🗒️",
             }
 
-            action_type = action["type"]
-            action_type = action_type[0].upper() + action_type[1:]
-            action_type = f"{action_emoji[action['type']]} {action_type}"
-
-            action_string = f"""**{action_type}**
+            action_string = f"""**{action_emoji[action['type']]} {action['type'][0].title()}**
                 **ID:** {action["id"]}
                 **Timestamp:** {datetime.fromtimestamp(action["timestamp"])} UTC
                 **Moderator:** <@!{action["mod_id"]}>
@@ -159,30 +137,31 @@ class NoteCommands(commands.Cog):
         latest edited message.
         """
         # TODO: Add some sort of support for history or editing mods.
-        await ctx.response.defer(thinking=True)
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         db = database.Database().get()
-        mod_log = db["mod_logs"].find_one(id=id)
-        if not mod_log:
+        log = db["mod_logs"].find_one(id=id)
+        if not log:
             return await embeds.error_message(ctx=ctx, description="Could not find a log with that ID!")
 
-        user = await self.bot.fetch_user(mod_log["user_id"])
+        user = await self.bot.fetch_user(log["user_id"])
         embed = embeds.make_embed(
             title=f"Edited log: {user.name}",
             description=f"Log #{id} for {user.mention} was updated by {ctx.user.mention}",
             thumbnail_url="https://i.imgur.com/A4c19BJ.png",
             color=discord.Color.green(),
             fields=[
-                {"name": "Before:", "value": mod_log["reason"], "inline": False},
+                {"name": "Before:", "value": log["reason"], "inline": False},
                 {"name": "After:", "value": note, "inline": False},
             ],
         )
 
-        mod_log["reason"] = note
-        db["mod_logs"].update(mod_log, ["id"])
+        log["reason"] = note
+        db["mod_logs"].update(log, ["id"])
         db.commit()
         db.close()
 
+        await log_embed_to_channel(ctx=ctx, embed=embed)
         await ctx.followup.send(embed=embed)
 
 

--- a/chiya/cogs/commands/server.py
+++ b/chiya/cogs/commands/server.py
@@ -18,22 +18,18 @@ class ServerCommands(commands.Cog):
     @app_commands.checks.has_role(config["roles"]["staff"])
     class ServerGroup(app_commands.Group):
         pass
-    server = ServerGroup(name="server", description="Server management commands", guild_ids=[config["guild_id"]])
+    server = ServerGroup(name="server", guild_ids=[config["guild_id"]])
 
     @server.command(name="pop", description="Gets the current server population")
     async def pop(self, ctx: discord.Interaction) -> None:
-        """
-        Send the current member count of the server.
-        """
+        """Send a message with the current guild member count."""
         await ctx.response.defer(thinking=True)
         await ctx.followup.send(ctx.guild.member_count)
 
     @server.command(name="boosters", description="List all the server boosters")
     async def boosters(self, ctx: discord.Interaction) -> None:
-        """
-        Send an embed with all current server boosters.
-        """
-        await ctx.response.defer(thinking=True)
+        """Send an embed listing all the current server boosters."""
+        await ctx.response.defer(thinking=True, ephemeral=True)
 
         embed = embeds.make_embed(
             title=f"Total boosts: {ctx.guild.premium_subscription_count}",

--- a/chiya/cogs/commands/trackerstatus.py
+++ b/chiya/cogs/commands/trackerstatus.py
@@ -63,7 +63,7 @@ class TrackerStatusCommands(commands.Cog):
     ) -> None:
         # TODO: Change the color of the embed to green if all services are online,
         # yellow if one of the services is offline, and grey or red if all are offline.
-        await ctx.response.defer()
+        await ctx.response.defer(ephemeral=True)
         tracker: TrackerStatus = trackers_dict.get(tracker)
 
         if tracker is None:

--- a/chiya/cogs/listeners/autoresponder.py
+++ b/chiya/cogs/listeners/autoresponder.py
@@ -22,7 +22,12 @@ class AutoresponderListeners(commands.Cog):
         and replies with the appopriate embed. Currently only when invoked
         by a staff member.
         """
+        # Ignore messages from bots to avoid infinite loops and other fuckery.
         if message.author.bot:
+            return
+
+        # Ignore DMs between users and the bot because .roles below will throw an exception.
+        if isinstance(message.channel, discord.channel.DMChannel):
             return
 
         staff = [x for x in message.author.roles

--- a/chiya/cogs/tasks/reminder.py
+++ b/chiya/cogs/tasks/reminder.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime, timezone
 
-import discord
 from discord.ext import commands, tasks
 
 from chiya import database
@@ -33,7 +32,6 @@ class ReminderTasks(commands.Cog):
             return db.close()
 
         for reminder in result:
-            channel = self.bot.get_channel(reminder["reminder_location"])
             try:
                 user = await self.bot.fetch_user(reminder["author_id"])
             except Exception:  # TODO: Add a proper Exception here
@@ -43,13 +41,9 @@ class ReminderTasks(commands.Cog):
 
             embed = embeds.make_embed(title="Here is your reminder", description=reminder["message"], color="blurple")
 
-            if channel:
-                try:
-                    await channel.send(user.mention, embed=embed)
-                except discord.HTTPException:
-                    dm = await user.create_dm()
-                    if not await dm.send(embed=embed):
-                        log.warning(f"Unable to post or DM {user}'s reminder {reminder['id']=}.")
+            dm = await user.create_dm()
+            if not await dm.send(embed=embed):
+                log.warning(f"Unable to post or DM {user}'s reminder {reminder['id']=}.")
 
             db["remind_me"].update(dict(id=reminder["id"], sent=True), ["id"])
 

--- a/chiya/utils/helpers.py
+++ b/chiya/utils/helpers.py
@@ -94,5 +94,7 @@ def get_duration(duration) -> tuple[str, int]:
 
 
 async def log_embed_to_channel(ctx: discord.Interaction, embed: discord.Embed):
-    channel = discord.utils.get(ctx.guild.text_channels, id=config["channels"]["logs"]["chiya"])
-    await channel.send(embed=embed)
+    mod_channel = discord.utils.get(ctx.guild.text_channels, id=config["channels"]["mod"]["moderation"])
+    logs_channel = discord.utils.get(ctx.guild.text_channels, id=config["channels"]["logs"]["chiya"])
+    await mod_channel.send(embed=embed)
+    await logs_channel.send(embed=embed)

--- a/chiya/utils/helpers.py
+++ b/chiya/utils/helpers.py
@@ -4,11 +4,13 @@ import re
 
 import discord
 
+from chiya import config
+
 
 log = logging.getLogger(__name__)
 
 
-async def can_action_member(ctx: discord.Interaction, member: discord.Member | discord.User) -> bool:
+def can_action_member(ctx: discord.Interaction, member: discord.Member | discord.User) -> bool:
     # Allow owner to override all limitations.
     if member.id == ctx.guild.owner_id:
         return True
@@ -89,3 +91,8 @@ def get_duration(duration) -> tuple[str, int]:
     end_time = int(datetime.datetime.timestamp(datetime.datetime.now(tz=datetime.timezone.utc) + time_delta))
 
     return duration_string, end_time
+
+
+async def log_embed_to_channel(ctx: discord.Interaction, embed: discord.Embed):
+    channel = discord.utils.get(ctx.guild.text_channels, id=config["channels"]["logs"]["chiya"])
+    await channel.send(embed=embed)


### PR DESCRIPTION
- Mod actions are now ephemeral and action embeds are logged to a channel.
- Reminders are now ephemeral, no longer attempt to send in the channel they were invoked in, and just send to the user's DMs instead. The user is warned when they create the reminder that they need to keep their DMs open.
- Finally got around to cleaning up the admin cog.
- Various comment and docstring cleanups across the codebase.
- Separated embeds that the user receives and embeds that the moderator receives into `user_embed` and `mod_embed` across the codebase for clarity and consistency.
- Made various helper functions that didn't need to be async into sync functions.
- Cleaned up function names and excessively verbose code where possible.
- Removed descriptions from command groups because they often cause PEP8 line length violations yet aren't even publicly facing to the user anywhere that I can tell.